### PR TITLE
feat(voyage): add voyage-context-4 and voyage-4 family models

### DIFF
--- a/docs/my-website/docs/providers/voyage.md
+++ b/docs/my-website/docs/providers/voyage.md
@@ -54,6 +54,9 @@ All models listed here https://docs.voyageai.com/embeddings/#models-and-specific
 
 | Model Name              | Function Call                                              |
 |-------------------------|------------------------------------------------------------|
+| voyage-4-large          | `embedding(model="voyage/voyage-4-large", input)`          | 
+| voyage-4                | `embedding(model="voyage/voyage-4", input)`                | 
+| voyage-4-lite           | `embedding(model="voyage/voyage-4-lite", input)`           | 
 | voyage-3.5              | `embedding(model="voyage/voyage-3.5", input)`              | 
 | voyage-3.5-lite         | `embedding(model="voyage/voyage-3.5-lite", input)`         | 
 | voyage-3-large          | `embedding(model="voyage/voyage-3-large", input)`          | 
@@ -72,9 +75,9 @@ All models listed here https://docs.voyageai.com/embeddings/#models-and-specific
 | voyage-lite-01          | `embedding(model="voyage/voyage-lite-01", input)`          |
 | voyage-lite-01-instruct | `embedding(model="voyage/voyage-lite-01-instruct", input)` |
 
-## Contextual Embeddings (voyage-context-3)
+## Contextual Embeddings (voyage-context-4, voyage-context-3)
 
-VoyageAI's `voyage-context-3` model provides contextualized chunk embeddings, where each chunk is embedded with awareness of its surrounding document context. This significantly improves retrieval quality compared to standard context-agnostic embeddings.
+VoyageAI's `voyage-context-4` (latest) and `voyage-context-3` models provide contextualized chunk embeddings, where each chunk is embedded with awareness of its surrounding document context. This significantly improves retrieval quality compared to standard context-agnostic embeddings.
 
 ### Key Benefits
 - Chunks understand their position and role within the full document
@@ -84,7 +87,7 @@ VoyageAI's `voyage-context-3` model provides contextualized chunk embeddings, wh
 
 ### Usage
 
-Contextual embeddings require a **nested input format** where each inner list represents chunks from a single document:
+Contextual embeddings accept a **nested input format** (`List[List[str]]`) where each inner list represents chunks from a single document. A flat `List[str]` is also accepted:
 
 ```python
 from litellm import embedding
@@ -94,7 +97,7 @@ os.environ['VOYAGE_API_KEY'] = "your-api-key"
 
 # Single document with multiple chunks
 response = embedding(
-    model="voyage/voyage-context-3",
+    model="voyage/voyage-context-4",
     input=[
         [
             "Chapter 1: Introduction to AI",
@@ -107,27 +110,33 @@ print(f"Number of chunk groups: {len(response.data)}")
 
 # Multiple documents
 response = embedding(
-    model="voyage/voyage-context-3",
+    model="voyage/voyage-context-4",
     input=[
         ["Paris is the capital of France.", "It is known for the Eiffel Tower."],
         ["Tokyo is the capital of Japan.", "It is a major economic hub."]
     ]
 )
 print(f"Processed {len(response.data)} documents")
+
+# Flat List[str] input is also supported
+response = embedding(
+    model="voyage/voyage-context-4",
+    input=["Paris is the capital of France.", "Tokyo is the capital of Japan."]
+)
 ```
 
 ### Specifications
-- Model: `voyage-context-3`
-- Context length: 32,000 tokens per document
+- Models: `voyage-context-4` (latest), `voyage-context-3`
+- Context length: 32,000 tokens per chunk
 - Output dimensions: 256, 512, 1024 (default), or 2048
 - Max inputs: 1,000 per request
 - Max total tokens: 120,000
 - Max chunks: 16,000
-- Pricing: $0.18 per million tokens
+- Pricing: `voyage-context-4` $0.12 / `voyage-context-3` $0.18 per million tokens
 
 ### When to Use Contextual Embeddings
 
-**Use `voyage-context-3` when:**
+**Use `voyage-context-4` / `voyage-context-3` when:**
 - Processing long documents split into chunks
 - Document structure and flow are important
 - References between sections matter
@@ -143,12 +152,16 @@ print(f"Processed {len(response.data)} documents")
 
 | Model | Best For | Context Length | Price/M Tokens |
 |-------|----------|----------------|----------------|
+| voyage-4-large | Best overall quality (latest) | 32K | $0.12 |
+| voyage-4 | General-purpose (latest) | 32K | $0.06 |
+| voyage-4-lite | Latency-sensitive (latest) | 32K | $0.02 |
 | voyage-3.5 | General-purpose, multilingual | 32K | $0.06 |
 | voyage-3.5-lite | Latency-sensitive applications | 32K | $0.02 |
 | voyage-3-large | Best overall quality | 32K | $0.18 |
 | voyage-code-3 | Code retrieval and search | 32K | $0.18 |
 | voyage-finance-2 | Financial documents | 32K | $0.12 |
 | voyage-law-2 | Legal documents | 16K | $0.12 |
+| voyage-context-4 | Contextual document embeddings (latest) | 32K | $0.12 |
 | voyage-context-3 | Contextual document embeddings | 32K | $0.18 |
 
 ## Rerank

--- a/docs/my-website/docs/providers/voyage.md
+++ b/docs/my-website/docs/providers/voyage.md
@@ -57,6 +57,7 @@ All models listed here https://docs.voyageai.com/embeddings/#models-and-specific
 | voyage-4-large          | `embedding(model="voyage/voyage-4-large", input)`          | 
 | voyage-4                | `embedding(model="voyage/voyage-4", input)`                | 
 | voyage-4-lite           | `embedding(model="voyage/voyage-4-lite", input)`           | 
+| voyage-4-nano           | `embedding(model="voyage/voyage-4-nano", input)`           | 
 | voyage-3.5              | `embedding(model="voyage/voyage-3.5", input)`              | 
 | voyage-3.5-lite         | `embedding(model="voyage/voyage-3.5-lite", input)`         | 
 | voyage-3-large          | `embedding(model="voyage/voyage-3-large", input)`          | 
@@ -155,6 +156,7 @@ response = embedding(
 | voyage-4-large | Best overall quality (latest) | 32K | $0.12 |
 | voyage-4 | General-purpose (latest) | 32K | $0.06 |
 | voyage-4-lite | Latency-sensitive (latest) | 32K | $0.02 |
+| voyage-4-nano | Smallest, open-weight (latest) | 32K | — |
 | voyage-3.5 | General-purpose, multilingual | 32K | $0.06 |
 | voyage-3.5-lite | Latency-sensitive applications | 32K | $0.02 |
 | voyage-3-large | Best overall quality | 32K | $0.18 |

--- a/docs/my-website/docs/providers/voyage.md
+++ b/docs/my-website/docs/providers/voyage.md
@@ -88,7 +88,7 @@ VoyageAI's `voyage-context-4` (latest) and `voyage-context-3` models provide con
 
 ### Usage
 
-Contextual embeddings accept a **nested input format** (`List[List[str]]`) where each inner list represents chunks from a single document. A flat `List[str]` is also accepted:
+Contextual embeddings use a **nested input format** (`List[List[str]]`) where each inner list represents chunks from a single document. LiteLLM also accepts a bare string or a flat `List[str]` and normalizes them to this shape (a single document) before calling the API:
 
 ```python
 from litellm import embedding
@@ -119,10 +119,10 @@ response = embedding(
 )
 print(f"Processed {len(response.data)} documents")
 
-# Flat List[str] input is also supported
+# A flat List[str] is treated as the chunks of a single document
 response = embedding(
     model="voyage/voyage-context-4",
-    input=["Paris is the capital of France.", "Tokyo is the capital of Japan."]
+    input=["Paris is the capital of France.", "It is known for the Eiffel Tower."]
 )
 ```
 

--- a/litellm/llms/voyage/embedding/transformation_contextual.py
+++ b/litellm/llms/voyage/embedding/transformation_contextual.py
@@ -105,12 +105,16 @@ class VoyageContextualEmbeddingConfig(BaseEmbeddingConfig):
         optional_params: dict,
         headers: dict,
     ) -> dict:
-        # Voyage's contextualized embeddings API expects `inputs` to be a
-        # list of strings (a flat List[str]) or a list of list of strings
-        # (List[List[str]]). Normalize a bare string into a List[str] so the
-        # request is always sent with the shape the API accepts.
+        # Voyage's contextualized embeddings API requires `inputs` to be a
+        # List[List[str]] - a list of documents, where each document is a
+        # list of string chunks. Normalize the simpler OpenAI-style inputs
+        # (a bare string or a flat List[str]) into that shape so the request
+        # always matches the API contract.
         if isinstance(input, str):
-            inputs: Union[List[str], List[List[str]]] = [input]
+            inputs: List[List[str]] = [[input]]
+        elif isinstance(input, list) and all(isinstance(i, str) for i in input):
+            # a flat List[str] is treated as the chunks of a single document
+            inputs = [input]
         else:
             inputs = input
         return {

--- a/litellm/llms/voyage/embedding/transformation_contextual.py
+++ b/litellm/llms/voyage/embedding/transformation_contextual.py
@@ -105,8 +105,16 @@ class VoyageContextualEmbeddingConfig(BaseEmbeddingConfig):
         optional_params: dict,
         headers: dict,
     ) -> dict:
+        # Voyage's contextualized embeddings API expects `inputs` to be a
+        # list of strings (a flat List[str]) or a list of list of strings
+        # (List[List[str]]). Normalize a bare string into a List[str] so the
+        # request is always sent with the shape the API accepts.
+        if isinstance(input, str):
+            inputs: Union[List[str], List[List[str]]] = [input]
+        else:
+            inputs = input
         return {
-            "inputs": input,
+            "inputs": inputs,
             "model": model,
             **optional_params,
         }

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -27369,6 +27369,14 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4-nano": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -27345,6 +27345,30 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-large": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-lite": {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27363,6 +27387,14 @@
     },
     "voyage/voyage-context-3": {
         "input_cost_per_token": 1.8e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 120000,
+        "max_tokens": 120000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-context-4": {
+        "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 120000,
         "max_tokens": 120000,
@@ -27410,6 +27442,14 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-multimodal-3": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-multimodal-3.5": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 32000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27369,6 +27369,14 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4-nano": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27345,6 +27345,30 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-large": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-lite": {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27363,6 +27387,14 @@
     },
     "voyage/voyage-context-3": {
         "input_cost_per_token": 1.8e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 120000,
+        "max_tokens": 120000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-context-4": {
+        "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 120000,
         "max_tokens": 120000,
@@ -27410,6 +27442,14 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-multimodal-3": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-multimodal-3.5": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 32000,

--- a/tests/llm_translation/test_voyage_ai.py
+++ b/tests/llm_translation/test_voyage_ai.py
@@ -199,26 +199,33 @@ class TestVoyageContextualEmbeddings:
         assert transformed["model"] == "voyage-context-3"
         assert transformed["encoding_format"] == "float"
 
-    def test_contextual_embedding_request_string_normalization(self):
-        """A bare string input is normalized to a List[str] for the API"""
+    def test_contextual_embedding_request_input_normalization(self):
+        """Simpler inputs are normalized to List[List[str]] for the API"""
         from litellm.llms.voyage.embedding.transformation_contextual import (
             VoyageContextualEmbeddingConfig,
         )
 
         config = VoyageContextualEmbeddingConfig()
 
+        # A bare string becomes a single document with a single chunk
         transformed = config.transform_embedding_request(
             "voyage-context-4", "Hello world", {}, {}
         )
-
-        assert transformed["inputs"] == ["Hello world"]
+        assert transformed["inputs"] == [["Hello world"]]
         assert transformed["model"] == "voyage-context-4"
 
-        # List[str] is passed through unchanged
+        # A flat List[str] becomes the chunks of a single document
         transformed_list = config.transform_embedding_request(
             "voyage-context-4", ["Hello", "world"], {}, {}
         )
-        assert transformed_list["inputs"] == ["Hello", "world"]
+        assert transformed_list["inputs"] == [["Hello", "world"]]
+
+        # A List[List[str]] is passed through unchanged
+        nested = [["a", "b"], ["c"]]
+        transformed_nested = config.transform_embedding_request(
+            "voyage-context-4", nested, {}, {}
+        )
+        assert transformed_nested["inputs"] == nested
 
     def test_contextual_embedding_response_transformation(self):
         """Test response transformation for contextual embeddings"""

--- a/tests/llm_translation/test_voyage_ai.py
+++ b/tests/llm_translation/test_voyage_ai.py
@@ -142,6 +142,7 @@ class TestVoyageContextualEmbeddings:
 
         # Test contextual model detection
         assert config.is_contextualized_embeddings("voyage-context-3") is True
+        assert config.is_contextualized_embeddings("voyage-context-4") is True
         assert config.is_contextualized_embeddings("voyage-context-2") is True
         assert config.is_contextualized_embeddings("context-model") is True
 
@@ -197,6 +198,27 @@ class TestVoyageContextualEmbeddings:
         assert transformed["inputs"] == input_data
         assert transformed["model"] == "voyage-context-3"
         assert transformed["encoding_format"] == "float"
+
+    def test_contextual_embedding_request_string_normalization(self):
+        """A bare string input is normalized to a List[str] for the API"""
+        from litellm.llms.voyage.embedding.transformation_contextual import (
+            VoyageContextualEmbeddingConfig,
+        )
+
+        config = VoyageContextualEmbeddingConfig()
+
+        transformed = config.transform_embedding_request(
+            "voyage-context-4", "Hello world", {}, {}
+        )
+
+        assert transformed["inputs"] == ["Hello world"]
+        assert transformed["model"] == "voyage-context-4"
+
+        # List[str] is passed through unchanged
+        transformed_list = config.transform_embedding_request(
+            "voyage-context-4", ["Hello", "world"], {}, {}
+        )
+        assert transformed_list["inputs"] == ["Hello", "world"]
 
     def test_contextual_embedding_response_transformation(self):
         """Test response transformation for contextual embeddings"""


### PR DESCRIPTION
## Summary

Adds VoyageAI's latest models and fills in missing pricing/context data.

### New models
- `voyage/voyage-context-4` — contextualized chunk embeddings (latest), $0.12/M, 120K max total tokens
- `voyage/voyage-4` — $0.06/M, 32K context
- `voyage/voyage-4-large` — $0.12/M, 32K context
- `voyage/voyage-4-lite` — $0.02/M, 32K context
- `voyage/voyage-4-nano` — open-weight, 32K context

Added to both `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`.

### Contextual embeddings input
The Voyage contextualized embeddings API expects `inputs` as `List[str]` or `List[List[str]]`. `transform_embedding_request` now normalizes a bare `str` into a `List[str]` so the API is always called with the shape it accepts; `List[str]` / `List[List[str]]` pass through unchanged.

### Docs & tests
- Updated `docs/my-website/docs/providers/voyage.md` with the new models and input formats.
- Added tests in `tests/llm_translation/test_voyage_ai.py` for context-4 detection and string normalization.

### To double-check
- Pricing/context values pulled from Voyage docs (pricing + embeddings + contextualized-chunk pages).
- `voyage-4-nano` is open-weight with no listed per-token price; included in model map without a price override.