### PR TITLE
feat(voyage): add voyage-context-4 and voyage-4 family models

### DIFF
--- a/litellm/llms/voyage/embedding/transformation_contextual.py
+++ b/litellm/llms/voyage/embedding/transformation_contextual.py
@@ -106,10 +106,30 @@ class VoyageContextualEmbeddingConfig(BaseEmbeddingConfig):
         headers: dict,
     ) -> dict:
         return {
-            "inputs": input,
+            "inputs": self._normalize_inputs(input),
             "model": model,
             **optional_params,
         }
+
+    @staticmethod
+    def _normalize_inputs(
+        input: Union[AllEmbeddingInputValues, List[List[str]]],
+    ) -> List[List[str]]:
+        """
+        The Voyage contextualized embeddings API expects `inputs` to be a list of
+        lists of strings (each inner list is a query/document made up of chunks).
+
+        Normalize the OpenAI-style embedding input so we always call the API with
+        list[str] entries:
+        - str                 -> [[str]]
+        - list[str]           -> [list[str]]  (one document, ordered chunks)
+        - list[list[str]]     -> unchanged
+        """
+        if isinstance(input, str):
+            return [[input]]
+        if isinstance(input, list) and all(isinstance(item, str) for item in input):
+            return [input]  # type: ignore[list-item]
+        return input  # type: ignore[return-value]
 
     def transform_embedding_response(
         self,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -27345,6 +27345,38 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-large": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-lite": {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-nano": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27369,6 +27401,14 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-context-4": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 120000,
+        "max_tokens": 120000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-finance-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27378,6 +27418,14 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-large-2": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 16000,
+        "max_tokens": 16000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-large-2-instruct": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 16000,
@@ -27410,6 +27458,14 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-multimodal-3": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-multilingual-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 32000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27345,6 +27345,38 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-large": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-lite": {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-nano": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27369,6 +27401,14 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-context-4": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 120000,
+        "max_tokens": 120000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-finance-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27378,6 +27418,14 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-large-2": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 16000,
+        "max_tokens": 16000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-large-2-instruct": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 16000,
@@ -27410,6 +27458,14 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-multimodal-3": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-multilingual-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 32000,

--- a/tests/llm_translation/test_voyage_ai.py
+++ b/tests/llm_translation/test_voyage_ai.py
@@ -142,6 +142,7 @@ class TestVoyageContextualEmbeddings:
 
         # Test contextual model detection
         assert config.is_contextualized_embeddings("voyage-context-3") is True
+        assert config.is_contextualized_embeddings("voyage-context-4") is True
         assert config.is_contextualized_embeddings("voyage-context-2") is True
         assert config.is_contextualized_embeddings("context-model") is True
 
@@ -197,6 +198,29 @@ class TestVoyageContextualEmbeddings:
         assert transformed["inputs"] == input_data
         assert transformed["model"] == "voyage-context-3"
         assert transformed["encoding_format"] == "float"
+
+    def test_contextual_embedding_input_normalization(self):
+        """Contextual API must be called with list[list[str]] inputs"""
+        from litellm.llms.voyage.embedding.transformation_contextual import (
+            VoyageContextualEmbeddingConfig,
+        )
+
+        config = VoyageContextualEmbeddingConfig()
+
+        # str -> [[str]]
+        assert config.transform_embedding_request(
+            "voyage-context-4", "hello", {}, {}
+        )["inputs"] == [["hello"]]
+
+        # list[str] -> [list[str]] (one document, ordered chunks)
+        assert config.transform_embedding_request(
+            "voyage-context-4", ["a", "b"], {}, {}
+        )["inputs"] == [["a", "b"]]
+
+        # list[list[str]] -> unchanged
+        assert config.transform_embedding_request(
+            "voyage-context-4", [["a", "b"], ["c"]], {}, {}
+        )["inputs"] == [["a", "b"], ["c"]]
 
     def test_contextual_embedding_response_transformation(self):
         """Test response transformation for contextual embeddings"""


### PR DESCRIPTION
## Summary

Adds `voyage-context-4` and fills in the other missing Voyage AI models with pricing and context windows. Also normalizes contextual embedding input so the Voyage contextualized embeddings API is always called with `list[str]` entries.

### New models
| Model | input_cost_per_token | max tokens | mode |
|---|---|---|---|
| `voyage/voyage-context-4` | 1.2e-07 ($0.12/1M) | 120000 | embedding |
| `voyage/voyage-4` | 6e-08 ($0.06/1M) | 32000 | embedding |
| `voyage/voyage-4-large` | 1.2e-07 ($0.12/1M) | 32000 | embedding |
| `voyage/voyage-4-lite` | 2e-08 ($0.02/1M) | 32000 | embedding |
| `voyage/voyage-4-nano` | 0.0 (free) | 32000 | embedding |
| `voyage/voyage-multilingual-2` | 1.2e-07 ($0.12/1M) | 32000 | embedding |
| `voyage/voyage-large-2-instruct` | 1.2e-07 ($0.12/1M) | 16000 | embedding |

`voyage-4-nano` is the free open-weight model ($0.0), works with the latest `voyageai` package.

### Contextual input normalization
The contextualized embeddings API (`/v1/contextualizedembeddings`) requires `inputs` to be `list[list[str]]`. `transform_embedding_request` now normalizes:
- `str` -> `[[str]]`
- `list[str]` -> `[list[str]]` (one document, ordered chunks)
- `list[list[str]]` -> unchanged

## Files changed
- `model_prices_and_context_window.json` — new model entries
- `litellm/model_prices_and_context_window_backup.json` — same entries (packaged map)
- `litellm/llms/voyage/embedding/transformation_contextual.py` — input normalization
- `tests/llm_translation/test_voyage_ai.py` — tests for context-4 detection + input normalization

## Notes for reviewer
- Prices per Voyage AI pricing page; context windows per Voyage docs.
- `make test`: `tests/llm_translation/test_voyage_ai.py` passes (16 passed, 1 skipped).
- Verify prices/context windows match current Voyage AI docs.