### PR TITLE
feat(voyage): add voyage-context-4, voyage-4 family, and voyage-4-nano

### DIFF
--- a/litellm/llms/voyage/embedding/transformation_contextual.py
+++ b/litellm/llms/voyage/embedding/transformation_contextual.py
@@ -106,10 +106,30 @@ class VoyageContextualEmbeddingConfig(BaseEmbeddingConfig):
         headers: dict,
     ) -> dict:
         return {
-            "inputs": input,
+            "inputs": self._normalize_inputs(input),
             "model": model,
             **optional_params,
         }
+
+    @staticmethod
+    def _normalize_inputs(
+        input: Union[AllEmbeddingInputValues, List[List[str]]],
+    ) -> List[List[str]]:
+        """
+        The Voyage contextualized embeddings API expects ``inputs`` to be a
+        list of documents, where each document is a ``list[str]`` of chunks.
+
+        Normalize the OpenAI-style embedding input so the API is always called
+        with ``list[list[str]]``:
+        - ``"text"`` (str)            -> ``[["text"]]``
+        - ``["a", "b"]`` (list[str])  -> ``[["a", "b"]]`` (single document)
+        - ``[["a", "b"], ["c"]]``     -> unchanged (list[list[str]])
+        """
+        if isinstance(input, str):
+            return [[input]]
+        if isinstance(input, list) and all(isinstance(item, str) for item in input):
+            return [input]  # type: ignore[list-item]
+        return input  # type: ignore[return-value]
 
     def transform_embedding_response(
         self,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -27345,6 +27345,38 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-large": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-lite": {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-nano": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27363,6 +27395,14 @@
     },
     "voyage/voyage-context-3": {
         "input_cost_per_token": 1.8e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 120000,
+        "max_tokens": 120000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-context-4": {
+        "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 120000,
         "max_tokens": 120000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27345,6 +27345,38 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-large": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-lite": {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-nano": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27363,6 +27395,14 @@
     },
     "voyage/voyage-context-3": {
         "input_cost_per_token": 1.8e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 120000,
+        "max_tokens": 120000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-context-4": {
+        "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 120000,
         "max_tokens": 120000,

--- a/tests/llm_translation/test_voyage_ai.py
+++ b/tests/llm_translation/test_voyage_ai.py
@@ -141,6 +141,7 @@ class TestVoyageContextualEmbeddings:
         config = VoyageContextualEmbeddingConfig()
 
         # Test contextual model detection
+        assert config.is_contextualized_embeddings("voyage-context-4") is True
         assert config.is_contextualized_embeddings("voyage-context-3") is True
         assert config.is_contextualized_embeddings("voyage-context-2") is True
         assert config.is_contextualized_embeddings("context-model") is True
@@ -197,6 +198,29 @@ class TestVoyageContextualEmbeddings:
         assert transformed["inputs"] == input_data
         assert transformed["model"] == "voyage-context-3"
         assert transformed["encoding_format"] == "float"
+
+    def test_contextual_embedding_input_normalization(self):
+        """Contextual API must always be called with list[list[str]]"""
+        from litellm.llms.voyage.embedding.transformation_contextual import (
+            VoyageContextualEmbeddingConfig,
+        )
+
+        config = VoyageContextualEmbeddingConfig()
+
+        # A single string becomes one document with one chunk
+        assert config.transform_embedding_request(
+            "voyage-context-4", "hello", {}, {}
+        )["inputs"] == [["hello"]]
+
+        # A flat list[str] becomes one document with multiple chunks
+        assert config.transform_embedding_request(
+            "voyage-context-4", ["a", "b"], {}, {}
+        )["inputs"] == [["a", "b"]]
+
+        # Already-nested list[list[str]] is passed through unchanged
+        assert config.transform_embedding_request(
+            "voyage-context-4", [["a", "b"], ["c"]], {}, {}
+        )["inputs"] == [["a", "b"], ["c"]]
 
     def test_contextual_embedding_response_transformation(self):
         """Test response transformation for contextual embeddings"""


### PR DESCRIPTION
## What
Adds the current Voyage AI model lineup that was missing from the pricing/context registry, plus an input-normalization fix for contextual embeddings.

### New models
| Model | Mode | Price /1M | Max tokens |
|---|---|---|---|
| `voyage/voyage-context-4` | embedding (contextual) | $0.12 | 120,000 |
| `voyage/voyage-4` | embedding | $0.06 | 32,000 |
| `voyage/voyage-4-large` | embedding | $0.12 | 32,000 |
| `voyage/voyage-4-lite` | embedding | $0.02 | 32,000 |
| `voyage/voyage-4-nano` | embedding | **free ($0.0)** | 32,000 |

`voyage-4-nano` is free and works with the latest `voyageai` python package.

### Contextual input normalization
The Voyage contextualized embeddings API expects `inputs` as `list[list[str]]`
(a list of documents, each a list of chunks). `transform_embedding_request` now
normalizes OpenAI-style input so the API is always called correctly:
- `"text"` → `[["text"]]`
- `["a", "b"]` → `[["a", "b"]]`
- `[["a", "b"], ["c"]]` → unchanged

## Files
- `model_prices_and_context_window.json`
- `litellm/model_prices_and_context_window_backup.json`
- `litellm/llms/voyage/embedding/transformation_contextual.py`
- `tests/llm_translation/test_voyage_ai.py`

## Tests
`pytest tests/llm_translation/test_voyage_ai.py` → 16 passed, 1 skipped.

## Double-check
- Prices sourced from docs.voyageai.com pricing page (context-4 = $0.12, context-3 = $0.18).
- `voyage-4-nano` is not on the pricing page but is a free open model per the embeddings docs; set to $0.0.