### PR TITLE
feat(voyage): add voyage-context-4, voyage-4 family, and fill missing models

### DIFF
--- a/docs/my-website/docs/providers/voyage.md
+++ b/docs/my-website/docs/providers/voyage.md
@@ -54,6 +54,10 @@ All models listed here https://docs.voyageai.com/embeddings/#models-and-specific
 
 | Model Name              | Function Call                                              |
 |-------------------------|------------------------------------------------------------|
+| voyage-4-large          | `embedding(model="voyage/voyage-4-large", input)`          | 
+| voyage-4                | `embedding(model="voyage/voyage-4", input)`                | 
+| voyage-4-lite           | `embedding(model="voyage/voyage-4-lite", input)`           | 
+| voyage-4-nano           | `embedding(model="voyage/voyage-4-nano", input)`           | 
 | voyage-3.5              | `embedding(model="voyage/voyage-3.5", input)`              | 
 | voyage-3.5-lite         | `embedding(model="voyage/voyage-3.5-lite", input)`         | 
 | voyage-3-large          | `embedding(model="voyage/voyage-3-large", input)`          | 
@@ -72,9 +76,9 @@ All models listed here https://docs.voyageai.com/embeddings/#models-and-specific
 | voyage-lite-01          | `embedding(model="voyage/voyage-lite-01", input)`          |
 | voyage-lite-01-instruct | `embedding(model="voyage/voyage-lite-01-instruct", input)` |
 
-## Contextual Embeddings (voyage-context-3)
+## Contextual Embeddings (voyage-context-4, voyage-context-3)
 
-VoyageAI's `voyage-context-3` model provides contextualized chunk embeddings, where each chunk is embedded with awareness of its surrounding document context. This significantly improves retrieval quality compared to standard context-agnostic embeddings.
+VoyageAI's `voyage-context-4` and `voyage-context-3` models provide contextualized chunk embeddings, where each chunk is embedded with awareness of its surrounding document context. This significantly improves retrieval quality compared to standard context-agnostic embeddings.
 
 ### Key Benefits
 - Chunks understand their position and role within the full document
@@ -149,6 +153,11 @@ print(f"Processed {len(response.data)} documents")
 | voyage-code-3 | Code retrieval and search | 32K | $0.18 |
 | voyage-finance-2 | Financial documents | 32K | $0.12 |
 | voyage-law-2 | Legal documents | 16K | $0.12 |
+| voyage-4-large | Highest quality general-purpose | 32K | $0.12 |
+| voyage-4 | General-purpose, multilingual | 32K | $0.06 |
+| voyage-4-lite | Latency-sensitive applications | 32K | $0.02 |
+| voyage-4-nano | Free, open-weight | 32K | $0.00 |
+| voyage-context-4 | Contextual document embeddings | 32K | $0.18 |
 | voyage-context-3 | Contextual document embeddings | 32K | $0.18 |
 
 ## Rerank

--- a/docs/my-website/docs/providers/voyage.md
+++ b/docs/my-website/docs/providers/voyage.md
@@ -157,7 +157,7 @@ print(f"Processed {len(response.data)} documents")
 | voyage-4 | General-purpose, multilingual | 32K | $0.06 |
 | voyage-4-lite | Latency-sensitive applications | 32K | $0.02 |
 | voyage-4-nano | Free, open-weight | 32K | $0.00 |
-| voyage-context-4 | Contextual document embeddings | 32K | $0.18 |
+| voyage-context-4 | Contextual document embeddings | 32K | $0.12 |
 | voyage-context-3 | Contextual document embeddings | 32K | $0.18 |
 
 ## Rerank

--- a/litellm/llms/voyage/embedding/transformation_contextual.py
+++ b/litellm/llms/voyage/embedding/transformation_contextual.py
@@ -106,10 +106,25 @@ class VoyageContextualEmbeddingConfig(BaseEmbeddingConfig):
         headers: dict,
     ) -> dict:
         return {
-            "inputs": input,
+            "inputs": self._normalize_inputs(input),
             "model": model,
             **optional_params,
         }
+
+    @staticmethod
+    def _normalize_inputs(
+        input: Union[AllEmbeddingInputValues, List[List[str]]]
+    ) -> Union[List[str], List[List[str]]]:
+        """
+        The Voyage contextualized embeddings API expects ``inputs`` to be a
+        ``list[str]`` (or ``list[list[str]]`` for pre-chunked documents).
+
+        A single string is wrapped into a ``list[str]`` so we always call the
+        API with a list. Existing list inputs are passed through unchanged.
+        """
+        if isinstance(input, str):
+            return [input]
+        return input
 
     def transform_embedding_response(
         self,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -27402,7 +27402,7 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-context-4": {
-        "input_cost_per_token": 1.8e-07,
+        "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 120000,
         "max_tokens": 120000,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -27345,6 +27345,38 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-large": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-lite": {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-nano": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27369,6 +27401,14 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-context-4": {
+        "input_cost_per_token": 1.8e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 120000,
+        "max_tokens": 120000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-finance-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27378,6 +27418,14 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-large-2": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 16000,
+        "max_tokens": 16000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-large-2-instruct": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 16000,
@@ -27406,6 +27454,14 @@
         "litellm_provider": "voyage",
         "max_input_tokens": 4000,
         "max_tokens": 4000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-multilingual-2": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27402,7 +27402,7 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-context-4": {
-        "input_cost_per_token": 1.8e-07,
+        "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 120000,
         "max_tokens": 120000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27345,6 +27345,38 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-large": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-lite": {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-nano": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27369,6 +27401,14 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-context-4": {
+        "input_cost_per_token": 1.8e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 120000,
+        "max_tokens": 120000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-finance-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27378,6 +27418,14 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-large-2": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 16000,
+        "max_tokens": 16000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-large-2-instruct": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 16000,
@@ -27406,6 +27454,14 @@
         "litellm_provider": "voyage",
         "max_input_tokens": 4000,
         "max_tokens": 4000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-multilingual-2": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },

--- a/tests/llm_translation/test_voyage_ai.py
+++ b/tests/llm_translation/test_voyage_ai.py
@@ -142,6 +142,7 @@ class TestVoyageContextualEmbeddings:
 
         # Test contextual model detection
         assert config.is_contextualized_embeddings("voyage-context-3") is True
+        assert config.is_contextualized_embeddings("voyage-context-4") is True
         assert config.is_contextualized_embeddings("voyage-context-2") is True
         assert config.is_contextualized_embeddings("context-model") is True
 
@@ -197,6 +198,33 @@ class TestVoyageContextualEmbeddings:
         assert transformed["inputs"] == input_data
         assert transformed["model"] == "voyage-context-3"
         assert transformed["encoding_format"] == "float"
+
+    def test_contextual_embedding_request_normalizes_string_input(self):
+        """A bare string must be sent to the API as a list[str]"""
+        from litellm.llms.voyage.embedding.transformation_contextual import (
+            VoyageContextualEmbeddingConfig,
+        )
+
+        config = VoyageContextualEmbeddingConfig()
+
+        # Single string -> wrapped into list[str]
+        transformed = config.transform_embedding_request(
+            "voyage-context-4", "Hello world", {}, {}
+        )
+        assert transformed["inputs"] == ["Hello world"]
+        assert transformed["model"] == "voyage-context-4"
+
+        # Flat list[str] is passed through unchanged
+        transformed = config.transform_embedding_request(
+            "voyage-context-4", ["Hello", "world"], {}, {}
+        )
+        assert transformed["inputs"] == ["Hello", "world"]
+
+        # Pre-chunked list[list[str]] is passed through unchanged
+        transformed = config.transform_embedding_request(
+            "voyage-context-4", [["Hello", "world"]], {}, {}
+        )
+        assert transformed["inputs"] == [["Hello", "world"]]
 
     def test_contextual_embedding_response_transformation(self):
         """Test response transformation for contextual embeddings"""


### PR DESCRIPTION
## Summary
Adds the latest VoyageAI models and fills in previously missing ones.

### New models
- **voyage-context-4** — contextual chunk embeddings (max 120K tokens, \$0.18/M)
- **voyage-4-large** (\$0.12/M), **voyage-4** (\$0.06/M), **voyage-4-lite** (\$0.02/M) — all 32K context
- **voyage-4-nano** — free model (\$0.0), works with the latest `voyageai` python package

### Filled missing models
- **voyage-multilingual-2** (\$0.12/M, 32K)
- **voyage-large-2-instruct** (\$0.12/M, 16K)

### Contextual embeddings fix
The contextualized embeddings API is now always called with a `list[str]`: a bare
string input is wrapped into `["..."]`. Flat `list[str]` and pre-chunked
`list[list[str]]` inputs pass through unchanged.

## Files changed
- `model_prices_and_context_window.json` + `litellm/model_prices_and_context_window_backup.json` — new model entries
- `litellm/llms/voyage/embedding/transformation_contextual.py` — input normalization
- `tests/llm_translation/test_voyage_ai.py` — new tests (context-4 detection, string normalization)
- `docs/my-website/docs/providers/voyage.md` — docs update

## Notes for reviewer
- Prices sourced from VoyageAI pricing/embeddings docs. Please double-check `voyage-context-4` (\$0.18/M, matching voyage-context-3) — the pricing page render was ambiguous between \$0.12 and \$0.18/M; per-thousand rate (\$0.00018) confirms \$0.18/M.
- `make test-unit` scope: `tests/llm_translation/test_voyage_ai.py` passes (16 passed, 1 skipped).