### PR TITLE
feat(voyage): add voyage-context-4 and voyage-4 family models

### DIFF
--- a/litellm/llms/voyage/embedding/transformation_contextual.py
+++ b/litellm/llms/voyage/embedding/transformation_contextual.py
@@ -106,10 +106,31 @@ class VoyageContextualEmbeddingConfig(BaseEmbeddingConfig):
         headers: dict,
     ) -> dict:
         return {
-            "inputs": input,
+            "inputs": self._normalize_inputs(input),
             "model": model,
             **optional_params,
         }
+
+    @staticmethod
+    def _normalize_inputs(
+        input: Union[AllEmbeddingInputValues, List[List[str]]],
+    ) -> List[List[str]]:
+        """
+        Voyage's contextualized embeddings API expects ``inputs`` to be a
+        ``List[List[str]]`` - a list of documents, each document being a list of
+        string chunks. Normalize the OpenAI-style input into that shape:
+
+        - ``"chunk"``            -> ``[["chunk"]]``
+        - ``["chunk1", "chunk2"]`` -> ``[["chunk1", "chunk2"]]`` (single document)
+        - ``[["chunk1"], ["chunk2"]]`` -> unchanged (already list[list[str]])
+        """
+        if isinstance(input, str):
+            return [[input]]
+        if isinstance(input, list):
+            if all(isinstance(item, str) for item in input):
+                # list[str] -> one document made of these chunks
+                return [list(input)]  # type: ignore[list-item]
+        return input  # type: ignore[return-value]
 
     def transform_embedding_response(
         self,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -27345,6 +27345,38 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-large": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-lite": {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-nano": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27363,6 +27395,14 @@
     },
     "voyage/voyage-context-3": {
         "input_cost_per_token": 1.8e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 120000,
+        "max_tokens": 120000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-context-4": {
+        "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 120000,
         "max_tokens": 120000,
@@ -27410,6 +27450,14 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-multimodal-3": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-multimodal-3.5": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 32000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27345,6 +27345,38 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-large": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-lite": {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-nano": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27363,6 +27395,14 @@
     },
     "voyage/voyage-context-3": {
         "input_cost_per_token": 1.8e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 120000,
+        "max_tokens": 120000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-context-4": {
+        "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 120000,
         "max_tokens": 120000,
@@ -27410,6 +27450,14 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-multimodal-3": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-multimodal-3.5": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 32000,

--- a/tests/llm_translation/test_voyage_ai.py
+++ b/tests/llm_translation/test_voyage_ai.py
@@ -141,6 +141,7 @@ class TestVoyageContextualEmbeddings:
         config = VoyageContextualEmbeddingConfig()
 
         # Test contextual model detection
+        assert config.is_contextualized_embeddings("voyage-context-4") is True
         assert config.is_contextualized_embeddings("voyage-context-3") is True
         assert config.is_contextualized_embeddings("voyage-context-2") is True
         assert config.is_contextualized_embeddings("context-model") is True
@@ -197,6 +198,30 @@ class TestVoyageContextualEmbeddings:
         assert transformed["inputs"] == input_data
         assert transformed["model"] == "voyage-context-3"
         assert transformed["encoding_format"] == "float"
+
+    def test_contextual_embedding_input_normalization(self):
+        """Contextual API expects inputs as List[List[str]] - normalize accordingly"""
+        from litellm.llms.voyage.embedding.transformation_contextual import (
+            VoyageContextualEmbeddingConfig,
+        )
+
+        config = VoyageContextualEmbeddingConfig()
+
+        # A single string becomes one document with one chunk
+        assert config.transform_embedding_request(
+            "voyage-context-4", "hello", {}, {}
+        )["inputs"] == [["hello"]]
+
+        # A list[str] becomes a single document made of those chunks
+        assert config.transform_embedding_request(
+            "voyage-context-4", ["chunk1", "chunk2"], {}, {}
+        )["inputs"] == [["chunk1", "chunk2"]]
+
+        # An already-nested list[list[str]] is passed through unchanged
+        nested = [["a", "b"], ["c"]]
+        assert config.transform_embedding_request(
+            "voyage-context-4", nested, {}, {}
+        )["inputs"] == nested
 
     def test_contextual_embedding_response_transformation(self):
         """Test response transformation for contextual embeddings"""


### PR DESCRIPTION
## Summary

Adds new Voyage AI models with pricing and context windows, and fixes contextual embedding input shaping.

### New models (both `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`)
| Model | input_cost / 1M | max tokens | mode |
|-------|-----------------|------------|------|
| `voyage/voyage-context-4` | \$0.12 | 120000 | embedding (contextual) |
| `voyage/voyage-4` | \$0.06 | 32000 | embedding |
| `voyage/voyage-4-large` | \$0.12 | 32000 | embedding |
| `voyage/voyage-4-lite` | \$0.02 | 32000 | embedding |
| `voyage/voyage-4-nano` | **\$0.0 (free)** | 32000 | embedding |
| `voyage/voyage-multimodal-3.5` | \$0.12 | 32000 | embedding |

Prices/context lengths sourced from Voyage AI docs (pricing + embeddings + contextualized-chunk-embeddings pages). `voyage-4-nano` is the free open model that works with the latest `voyageai` python package.

### Contextual input normalization
The Voyage `contextualizedembeddings` API requires `inputs` to be `List[List[str]]`. `transform_embedding_request` now normalizes:
- `"chunk"` -> `[["chunk"]]`
- `["chunk1", "chunk2"]` -> `[["chunk1", "chunk2"]]` (single document)
- `[["a"], ["b"]]` -> unchanged

`voyage-context-4` is detected automatically via the existing `is_contextualized_embeddings` check (`"context" in model`).

### Tests
`tests/llm_translation/test_voyage_ai.py`: added context-4 detection assertion + input-normalization test. Full file passes (16 passed, 1 skipped).

## For the approver to double-check
- Confirm `voyage-multimodal-3.5` inclusion is desired (multimodal price also has a per-pixel component not modeled here, same as existing `voyage-multimodal-3`).
- Context length for `voyage-context-4` set to 120000 (per-chunk window 32000) matching `voyage-context-3`.