### PR TITLE
feat(voyage): add voyage-context-4 and voyage-4-nano models

### DIFF
--- a/docs/my-website/docs/providers/voyage.md
+++ b/docs/my-website/docs/providers/voyage.md
@@ -54,6 +54,9 @@ All models listed here https://docs.voyageai.com/embeddings/#models-and-specific
 
 | Model Name              | Function Call                                              |
 |-------------------------|------------------------------------------------------------|
+| voyage-context-4        | `embedding(model="voyage/voyage-context-4", input)`        | 
+| voyage-context-3        | `embedding(model="voyage/voyage-context-3", input)`        | 
+| voyage-4-nano           | `embedding(model="voyage/voyage-4-nano", input)`           | 
 | voyage-3.5              | `embedding(model="voyage/voyage-3.5", input)`              | 
 | voyage-3.5-lite         | `embedding(model="voyage/voyage-3.5-lite", input)`         | 
 | voyage-3-large          | `embedding(model="voyage/voyage-3-large", input)`          | 
@@ -72,9 +75,11 @@ All models listed here https://docs.voyageai.com/embeddings/#models-and-specific
 | voyage-lite-01          | `embedding(model="voyage/voyage-lite-01", input)`          |
 | voyage-lite-01-instruct | `embedding(model="voyage/voyage-lite-01-instruct", input)` |
 
-## Contextual Embeddings (voyage-context-3)
+## Contextual Embeddings (voyage-context-4, voyage-context-3)
 
-VoyageAI's `voyage-context-3` model provides contextualized chunk embeddings, where each chunk is embedded with awareness of its surrounding document context. This significantly improves retrieval quality compared to standard context-agnostic embeddings.
+VoyageAI's `voyage-context-4` and `voyage-context-3` models provide contextualized chunk embeddings, where each chunk is embedded with awareness of its surrounding document context. This significantly improves retrieval quality compared to standard context-agnostic embeddings. `voyage-context-4` is the latest generation and is recommended for new integrations.
+
+Both models are routed automatically to the contextualized embeddings API and are always called with `list[str]` inner elements (nested input format).
 
 ### Key Benefits
 - Chunks understand their position and role within the full document
@@ -117,17 +122,16 @@ print(f"Processed {len(response.data)} documents")
 ```
 
 ### Specifications
-- Model: `voyage-context-3`
-- Context length: 32,000 tokens per document
+- Models: `voyage-context-4`, `voyage-context-3`
+- Context length: 32,000 tokens per chunk (120,000 tokens total per request)
 - Output dimensions: 256, 512, 1024 (default), or 2048
 - Max inputs: 1,000 per request
-- Max total tokens: 120,000
 - Max chunks: 16,000
-- Pricing: $0.18 per million tokens
+- Pricing: `voyage-context-4` $0.12 / `voyage-context-3` $0.18 per million tokens
 
 ### When to Use Contextual Embeddings
 
-**Use `voyage-context-3` when:**
+**Use `voyage-context-4` / `voyage-context-3` when:**
 - Processing long documents split into chunks
 - Document structure and flow are important
 - References between sections matter
@@ -143,6 +147,8 @@ print(f"Processed {len(response.data)} documents")
 
 | Model | Best For | Context Length | Price/M Tokens |
 |-------|----------|----------------|----------------|
+| voyage-context-4 | Contextual document embeddings (latest) | 32K/chunk (120K total) | $0.12 |
+| voyage-4-nano | Free, lightweight general-purpose | 32K | $0.00 |
 | voyage-3.5 | General-purpose, multilingual | 32K | $0.06 |
 | voyage-3.5-lite | Latency-sensitive applications | 32K | $0.02 |
 | voyage-3-large | Best overall quality | 32K | $0.18 |

--- a/litellm/llms/voyage/embedding/transformation_contextual.py
+++ b/litellm/llms/voyage/embedding/transformation_contextual.py
@@ -98,6 +98,31 @@ class VoyageContextualEmbeddingConfig(BaseEmbeddingConfig):
             "Authorization": f"Bearer {api_key}",
         }
 
+    @staticmethod
+    def _transform_input_to_nested_list(
+        input: Union[AllEmbeddingInputValues, List[List[str]]],
+    ) -> List[List[str]]:
+        """
+        The Voyage contextualized embeddings API expects ``inputs`` to be a
+        list of lists of strings (``List[List[str]]``) - each inner list holds
+        a query, a document, or the chunks of a document.
+
+        Normalize the OpenAI-style ``input`` so we always call the API with
+        ``list[str]`` inner elements:
+        - ``"text"``               -> ``[["text"]]``
+        - ``["a", "b"]``           -> ``[["a", "b"]]``
+        - ``[["a", "b"], ["c"]]``  -> unchanged
+        """
+        if isinstance(input, str):
+            return [[input]]
+        if isinstance(input, list):
+            if len(input) > 0 and all(isinstance(item, str) for item in input):
+                # flat list[str] -> single group of chunks
+                return [input]  # type: ignore[list-item]
+            # already list[list[str]] (or empty) - pass through
+            return input  # type: ignore[return-value]
+        return input  # type: ignore[return-value]
+
     def transform_embedding_request(
         self,
         model: str,
@@ -106,7 +131,7 @@ class VoyageContextualEmbeddingConfig(BaseEmbeddingConfig):
         headers: dict,
     ) -> dict:
         return {
-            "inputs": input,
+            "inputs": self._transform_input_to_nested_list(input),
             "model": model,
             **optional_params,
         }

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -27345,6 +27345,14 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4-nano": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27363,6 +27371,14 @@
     },
     "voyage/voyage-context-3": {
         "input_cost_per_token": 1.8e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 120000,
+        "max_tokens": 120000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-context-4": {
+        "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 120000,
         "max_tokens": 120000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27345,6 +27345,14 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4-nano": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27363,6 +27371,14 @@
     },
     "voyage/voyage-context-3": {
         "input_cost_per_token": 1.8e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 120000,
+        "max_tokens": 120000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-context-4": {
+        "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 120000,
         "max_tokens": 120000,

--- a/tests/llm_translation/test_voyage_ai.py
+++ b/tests/llm_translation/test_voyage_ai.py
@@ -150,6 +150,46 @@ class TestVoyageContextualEmbeddings:
         assert config.is_contextualized_embeddings("voyage-2") is False
         assert config.is_contextualized_embeddings("regular-model") is False
 
+    def test_contextual_embedding_model_detection_context_4(self):
+        """voyage-context-4 must be routed to the contextual config"""
+        from litellm.llms.voyage.embedding.transformation_contextual import (
+            VoyageContextualEmbeddingConfig,
+        )
+
+        config = VoyageContextualEmbeddingConfig()
+        assert config.is_contextualized_embeddings("voyage-context-4") is True
+        assert config.is_contextualized_embeddings("voyage/voyage-context-4") is True
+
+    def test_contextual_embedding_input_normalized_to_nested_list(self):
+        """
+        The contextual API requires list[list[str]]. A plain string or a flat
+        list[str] must be wrapped so the API is always called with list[str].
+        """
+        from litellm.llms.voyage.embedding.transformation_contextual import (
+            VoyageContextualEmbeddingConfig,
+        )
+
+        config = VoyageContextualEmbeddingConfig()
+
+        # str -> [[str]]
+        transformed = config.transform_embedding_request(
+            "voyage-context-4", "Hello", {}, {}
+        )
+        assert transformed["inputs"] == [["Hello"]]
+
+        # flat list[str] -> single group of chunks
+        transformed = config.transform_embedding_request(
+            "voyage-context-4", ["Hello", "world"], {}, {}
+        )
+        assert transformed["inputs"] == [["Hello", "world"]]
+
+        # already list[list[str]] -> unchanged
+        nested = [["Hello", "world"], ["Test"]]
+        transformed = config.transform_embedding_request(
+            "voyage-context-4", nested, {}, {}
+        )
+        assert transformed["inputs"] == nested
+
     def test_contextual_embedding_url_generation(self):
         """Test URL generation for contextual embeddings"""
         from litellm.llms.voyage.embedding.transformation_contextual import (


### PR DESCRIPTION
## Summary
Adds two new Voyage AI embedding models and hardens contextual embedding input handling.

- **voyage-context-4** — latest contextualized chunk embedding model. \$0.12 / 1M tokens, 120K total tokens (32K per chunk), routed automatically to the contextualized embeddings API.
- **voyage-4-nano** — free, lightweight general-purpose embedding model. \$0.0, 32K tokens. Works with the latest `voyageai` python package.
- **Contextual input normalization** — the contextualized embeddings API requires `inputs` as `list[list[str]]`. A plain `str` or flat `list[str]` is now wrapped so the API is always called with `list[str]` inner elements:
  - `"text"` → `[["text"]]`
  - `["a", "b"]` → `[["a", "b"]]`
  - `[["a", "b"], ["c"]]` → unchanged
- Docs updated for the new models.

## Files changed
- `model_prices_and_context_window.json` — add voyage-context-4, voyage-4-nano
- `litellm/model_prices_and_context_window_backup.json` — same
- `litellm/llms/voyage/embedding/transformation_contextual.py` — normalize input to nested list
- `tests/llm_translation/test_voyage_ai.py` — tests for context-4 routing + input normalization
- `docs/my-website/docs/providers/voyage.md` — docs

## Verification
- `pytest tests/llm_translation/test_voyage_ai.py` → 17 passed, 1 skipped
- `get_model_info` returns correct cost/context for both new models (with local cost map)

## To double-check
- Confirm voyage-4-nano is intended to remain \$0.0 (free) in the price map.
- voyage-context-4 max total tokens set to 120,000 (per-chunk 32K), matching voyage-context-3.