### PR TITLE
feat(voyage): add voyage-context-4, voyage-4 family and missing models

### DIFF
--- a/docs/my-website/docs/providers/voyage.md
+++ b/docs/my-website/docs/providers/voyage.md
@@ -54,6 +54,10 @@ All models listed here https://docs.voyageai.com/embeddings/#models-and-specific
 
 | Model Name              | Function Call                                              |
 |-------------------------|------------------------------------------------------------|
+| voyage-4-large          | `embedding(model="voyage/voyage-4-large", input)`          | 
+| voyage-4                | `embedding(model="voyage/voyage-4", input)`                | 
+| voyage-4-lite           | `embedding(model="voyage/voyage-4-lite", input)`           | 
+| voyage-4-nano           | `embedding(model="voyage/voyage-4-nano", input)`           | 
 | voyage-3.5              | `embedding(model="voyage/voyage-3.5", input)`              | 
 | voyage-3.5-lite         | `embedding(model="voyage/voyage-3.5-lite", input)`         | 
 | voyage-3-large          | `embedding(model="voyage/voyage-3-large", input)`          | 
@@ -72,9 +76,9 @@ All models listed here https://docs.voyageai.com/embeddings/#models-and-specific
 | voyage-lite-01          | `embedding(model="voyage/voyage-lite-01", input)`          |
 | voyage-lite-01-instruct | `embedding(model="voyage/voyage-lite-01-instruct", input)` |
 
-## Contextual Embeddings (voyage-context-3)
+## Contextual Embeddings (voyage-context-4, voyage-context-3)
 
-VoyageAI's `voyage-context-3` model provides contextualized chunk embeddings, where each chunk is embedded with awareness of its surrounding document context. This significantly improves retrieval quality compared to standard context-agnostic embeddings.
+VoyageAI's `voyage-context-4` (recommended) and `voyage-context-3` models provide contextualized chunk embeddings, where each chunk is embedded with awareness of its surrounding document context. This significantly improves retrieval quality compared to standard context-agnostic embeddings.
 
 ### Key Benefits
 - Chunks understand their position and role within the full document
@@ -117,17 +121,17 @@ print(f"Processed {len(response.data)} documents")
 ```
 
 ### Specifications
-- Model: `voyage-context-3`
-- Context length: 32,000 tokens per document
+- Models: `voyage-context-4` (recommended), `voyage-context-3`
+- Context length: 32,000 tokens per chunk
 - Output dimensions: 256, 512, 1024 (default), or 2048
 - Max inputs: 1,000 per request
 - Max total tokens: 120,000
 - Max chunks: 16,000
-- Pricing: $0.18 per million tokens
+- Pricing: `voyage-context-4` $0.12 / `voyage-context-3` $0.18 per million tokens
 
 ### When to Use Contextual Embeddings
 
-**Use `voyage-context-3` when:**
+**Use `voyage-context-4` / `voyage-context-3` when:**
 - Processing long documents split into chunks
 - Document structure and flow are important
 - References between sections matter
@@ -143,12 +147,17 @@ print(f"Processed {len(response.data)} documents")
 
 | Model | Best For | Context Length | Price/M Tokens |
 |-------|----------|----------------|----------------|
+| voyage-4-large | Best overall quality | 32K | $0.12 |
+| voyage-4 | General-purpose, multilingual | 32K | $0.06 |
+| voyage-4-lite | Latency-sensitive applications | 32K | $0.02 |
+| voyage-4-nano | Open-weight, free | 32K | $0.00 |
 | voyage-3.5 | General-purpose, multilingual | 32K | $0.06 |
 | voyage-3.5-lite | Latency-sensitive applications | 32K | $0.02 |
 | voyage-3-large | Best overall quality | 32K | $0.18 |
 | voyage-code-3 | Code retrieval and search | 32K | $0.18 |
 | voyage-finance-2 | Financial documents | 32K | $0.12 |
 | voyage-law-2 | Legal documents | 16K | $0.12 |
+| voyage-context-4 | Contextual document embeddings | 32K | $0.12 |
 | voyage-context-3 | Contextual document embeddings | 32K | $0.18 |
 
 ## Rerank

--- a/litellm/llms/voyage/embedding/transformation_contextual.py
+++ b/litellm/llms/voyage/embedding/transformation_contextual.py
@@ -105,6 +105,11 @@ class VoyageContextualEmbeddingConfig(BaseEmbeddingConfig):
         optional_params: dict,
         headers: dict,
     ) -> dict:
+        # The Voyage contextualized embeddings API expects `inputs` to be a
+        # list of strings (or a list of list of strings for pre-chunked docs).
+        # A bare string is rejected by the API, so normalize it to list[str].
+        if isinstance(input, str):
+            input = [input]
         return {
             "inputs": input,
             "model": model,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -27345,6 +27345,38 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-large": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-lite": {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-nano": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27369,6 +27401,14 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-context-4": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 120000,
+        "max_tokens": 120000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-finance-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27378,6 +27418,14 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-large-2": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 16000,
+        "max_tokens": 16000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-large-2-instruct": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 16000,
@@ -27409,7 +27457,23 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-multilingual-2": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-multimodal-3": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-multimodal-3.5": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 32000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27345,6 +27345,38 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-large": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-lite": {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-nano": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27369,6 +27401,14 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-context-4": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 120000,
+        "max_tokens": 120000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-finance-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27378,6 +27418,14 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-large-2": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 16000,
+        "max_tokens": 16000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-large-2-instruct": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 16000,
@@ -27409,7 +27457,23 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-multilingual-2": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-multimodal-3": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-multimodal-3.5": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 32000,

--- a/tests/llm_translation/test_voyage_ai.py
+++ b/tests/llm_translation/test_voyage_ai.py
@@ -71,6 +71,26 @@ class TestVoyageAI(BaseLLMEmbeddingTest):
                 assert response.usage.total_tokens > 0
 
 
+@pytest.mark.parametrize(
+    "model, expected_cost, expected_max_tokens",
+    [
+        ("voyage/voyage-context-4", 1.2e-07, 120000),
+        ("voyage/voyage-4", 6e-08, 32000),
+        ("voyage/voyage-4-large", 1.2e-07, 32000),
+        ("voyage/voyage-4-lite", 2e-08, 32000),
+        ("voyage/voyage-4-nano", 0.0, 32000),
+    ],
+)
+def test_voyage_new_models_in_cost_map(model, expected_cost, expected_max_tokens):
+    """New Voyage models must be registered with the correct pricing"""
+    assert model in litellm.model_cost
+    info = litellm.model_cost[model]
+    assert info["litellm_provider"] == "voyage"
+    assert info["mode"] == "embedding"
+    assert info["input_cost_per_token"] == expected_cost
+    assert info["max_input_tokens"] == expected_max_tokens
+
+
 def test_voyage_ai_embedding_extra_params():
     """Test Voyage AI embedding with extra parameters"""
     try:
@@ -142,6 +162,7 @@ class TestVoyageContextualEmbeddings:
 
         # Test contextual model detection
         assert config.is_contextualized_embeddings("voyage-context-3") is True
+        assert config.is_contextualized_embeddings("voyage-context-4") is True
         assert config.is_contextualized_embeddings("voyage-context-2") is True
         assert config.is_contextualized_embeddings("context-model") is True
 
@@ -197,6 +218,27 @@ class TestVoyageContextualEmbeddings:
         assert transformed["inputs"] == input_data
         assert transformed["model"] == "voyage-context-3"
         assert transformed["encoding_format"] == "float"
+
+    def test_contextual_embedding_request_string_normalization(self):
+        """A bare string input must be normalized to list[str] for the API"""
+        from litellm.llms.voyage.embedding.transformation_contextual import (
+            VoyageContextualEmbeddingConfig,
+        )
+
+        config = VoyageContextualEmbeddingConfig()
+
+        transformed = config.transform_embedding_request(
+            "voyage-context-4", "Hello world", {}, {}
+        )
+
+        assert transformed["inputs"] == ["Hello world"]
+        assert transformed["model"] == "voyage-context-4"
+
+        # Existing list inputs are passed through unchanged
+        transformed = config.transform_embedding_request(
+            "voyage-context-4", ["Hello", "world"], {}, {}
+        )
+        assert transformed["inputs"] == ["Hello", "world"]
 
     def test_contextual_embedding_response_transformation(self):
         """Test response transformation for contextual embeddings"""


### PR DESCRIPTION
## Summary

Adds the latest VoyageAI models and fills in missing ones with correct pricing.

### New models
- **voyage-context-4** — contextualized chunk embeddings (recommended), \$0.12/1M, 120K max tokens
- **voyage-4-large** (\$0.12), **voyage-4** (\$0.06), **voyage-4-lite** (\$0.02), all 32K
- **voyage-4-nano** — free open-weight model (\$0.0), 32K; works with latest `voyageai` package

### Missing models filled in
- voyage-large-2-instruct (\$0.12, 16K)
- voyage-multilingual-2 (\$0.12, 32K)
- voyage-multimodal-3.5 (\$0.12, 32K)

### Contextual API fix
- `voyage-context-4` auto-routes to the contextualized embeddings config (`"context"` substring match).
- Normalize a bare `str` input to `list[str]` in `transform_embedding_request`, since the contextualized embeddings API rejects a plain string.

### Files changed
- `litellm/model_prices_and_context_window_backup.json` + `model_prices_and_context_window.json` (kept in sync)
- `litellm/llms/voyage/embedding/transformation_contextual.py`
- `tests/llm_translation/test_voyage_ai.py`
- `docs/my-website/docs/providers/voyage.md`

### Double-check
- Prices sourced from VoyageAI pricing/docs (context-4 \$0.12, context-3 \$0.18).
- Both pricing JSON files are byte-identical after the edit.