### PR TITLE
feat(voyage): add voyage-context-4 & voyage-4 family models, prefer List[str] for contextual embeddings

### DIFF
--- a/docs/my-website/docs/providers/voyage.md
+++ b/docs/my-website/docs/providers/voyage.md
@@ -91,15 +91,16 @@ VoyageAI's contextual models (`voyage-context-4`, `voyage-context-3`) provide co
 
 ### Usage
 
-The Voyage contextual endpoint expects the `inputs` field as a **nested** `List[List[str]]`, where each inner list holds the chunks of a *single* document so they are embedded in each other's context. LiteLLM accepts the flatter forms for convenience and normalizes them to that nested shape before calling the API:
+The Voyage contextual `inputs` field accepts **both** a flat `List[str]` and a nested `List[List[str]]` (`Union[List[List[str]], List[str]]`). LiteLLM **prefers the flat `List[str]`** form whenever the input allows it and only falls back to the nested `List[List[str]]` when you supply pre-grouped chunks yourself:
 
-| You pass | LiteLLM sends |
-|----------|---------------|
-| `"Hello"` (a string) | `[["Hello"]]` |
-| `["chunk1", "chunk2"]` (flat list — chunks of one document) | `[["chunk1", "chunk2"]]` |
-| `[["c1", "c2"], ["d1"]]` (already nested — one list per document) | `[["c1", "c2"], ["d1"]]` (unchanged) |
+| You pass | LiteLLM sends (`inputs`) | Extra params |
+|----------|--------------------------|--------------|
+| `"Hello"` (a string) | `["Hello"]` (flat) | `input_type="document"`, `enable_auto_chunking=True` |
+| `["text1", "text2"]` (flat list of independent texts) | `["text1", "text2"]` (flat, kept) | `input_type="document"`, `enable_auto_chunking=True` |
+| `["query"]` with `input_type="query"` | `["query"]` (flat) | none |
+| `[["c1", "c2"], ["d1"]]` (already nested — one list per document) | `[["c1", "c2"], ["d1"]]` (unchanged) | none |
 
-A flat `List[str]` is treated as the chunks of one document; to contextualize **multiple** documents, pass the nested `List[List[str]]` form yourself.
+Why the extra params: a flat `List[str]` document input is only valid when auto-chunking is enabled, so LiteLLM sets `input_type="document"` + `enable_auto_chunking=True` for the flat document case (Voyage splits each string into chunks server-side). Queries (`input_type="query"`) accept a flat list directly, so nothing extra is added. When you pass a nested `List[List[str]]` (pre-grouped chunks that should share context), it is forwarded untouched and **no** auto-chunking params are injected. Any `input_type` / `enable_auto_chunking` you set explicitly is respected.
 
 ```python
 from litellm import embedding
@@ -107,18 +108,18 @@ import os
 
 os.environ['VOYAGE_API_KEY'] = "your-api-key"
 
-# Chunks of a single document (normalized to [["...", "...", "..."]])
+# Flat list of documents (sent as List[str], auto-chunked server-side)
 response = embedding(
     model="voyage/voyage-context-4",
     input=[
-        "Chapter 1: Introduction to AI",
-        "This chapter covers the basics of artificial intelligence.",
-        "We will explore machine learning and deep learning."
+        "Chapter 1: Introduction to AI. This chapter covers the basics.",
+        "Chapter 2: Machine learning and deep learning fundamentals."
     ]
 )
-print(f"Number of chunks: {len(response.data)}")
+print(f"Number of results: {len(response.data)}")
 
-# Multiple documents, each a group of chunks (sent as-is: List[List[str]])
+# Pre-grouped chunks — one inner list per document, embedded in shared context
+# (sent as-is: List[List[str]])
 response = embedding(
     model="voyage/voyage-context-4",
     input=[

--- a/docs/my-website/docs/providers/voyage.md
+++ b/docs/my-website/docs/providers/voyage.md
@@ -54,6 +54,10 @@ All models listed here https://docs.voyageai.com/embeddings/#models-and-specific
 
 | Model Name              | Function Call                                              |
 |-------------------------|------------------------------------------------------------|
+| voyage-4-large          | `embedding(model="voyage/voyage-4-large", input)`          | 
+| voyage-4                | `embedding(model="voyage/voyage-4", input)`                | 
+| voyage-4-lite           | `embedding(model="voyage/voyage-4-lite", input)`           | 
+| voyage-4-nano           | `embedding(model="voyage/voyage-4-nano", input)`           | 
 | voyage-3.5              | `embedding(model="voyage/voyage-3.5", input)`              | 
 | voyage-3.5-lite         | `embedding(model="voyage/voyage-3.5-lite", input)`         | 
 | voyage-3-large          | `embedding(model="voyage/voyage-3-large", input)`          | 
@@ -72,9 +76,9 @@ All models listed here https://docs.voyageai.com/embeddings/#models-and-specific
 | voyage-lite-01          | `embedding(model="voyage/voyage-lite-01", input)`          |
 | voyage-lite-01-instruct | `embedding(model="voyage/voyage-lite-01-instruct", input)` |
 
-## Contextual Embeddings (voyage-context-3)
+## Contextual Embeddings (voyage-context-4, voyage-context-3)
 
-VoyageAI's `voyage-context-3` model provides contextualized chunk embeddings, where each chunk is embedded with awareness of its surrounding document context. This significantly improves retrieval quality compared to standard context-agnostic embeddings.
+VoyageAI's contextual models (`voyage-context-4`, `voyage-context-3`) provide contextualized chunk embeddings, where each chunk is embedded with awareness of its surrounding document context. This significantly improves retrieval quality compared to standard context-agnostic embeddings.
 
 ### Key Benefits
 - Chunks understand their position and role within the full document
@@ -84,7 +88,7 @@ VoyageAI's `voyage-context-3` model provides contextualized chunk embeddings, wh
 
 ### Usage
 
-Contextual embeddings require a **nested input format** where each inner list represents chunks from a single document:
+Contextual embeddings accept both a flat `List[str]` and a **nested** `List[List[str]]` input. LiteLLM sends a `List[str]` to the Voyage API when the input allows it (a plain string or a flat list of chunks) and only falls back to the nested `List[List[str]]` shape when you supply pre-grouped chunks — one inner list per document.
 
 ```python
 from litellm import embedding
@@ -92,22 +96,20 @@ import os
 
 os.environ['VOYAGE_API_KEY'] = "your-api-key"
 
-# Single document with multiple chunks
+# Flat list of chunks (sent to the API as List[str])
 response = embedding(
-    model="voyage/voyage-context-3",
+    model="voyage/voyage-context-4",
     input=[
-        [
-            "Chapter 1: Introduction to AI",
-            "This chapter covers the basics of artificial intelligence.",
-            "We will explore machine learning and deep learning."
-        ]
+        "Chapter 1: Introduction to AI",
+        "This chapter covers the basics of artificial intelligence.",
+        "We will explore machine learning and deep learning."
     ]
 )
-print(f"Number of chunk groups: {len(response.data)}")
+print(f"Number of chunks: {len(response.data)}")
 
-# Multiple documents
+# Multiple documents, each a group of chunks (sent as List[List[str]])
 response = embedding(
-    model="voyage/voyage-context-3",
+    model="voyage/voyage-context-4",
     input=[
         ["Paris is the capital of France.", "It is known for the Eiffel Tower."],
         ["Tokyo is the capital of Japan.", "It is a major economic hub."]
@@ -117,17 +119,16 @@ print(f"Processed {len(response.data)} documents")
 ```
 
 ### Specifications
-- Model: `voyage-context-3`
-- Context length: 32,000 tokens per document
+- Models: `voyage-context-4` ($0.12/M tokens), `voyage-context-3` ($0.18/M tokens)
+- Per-chunk context window: 32,000 tokens
 - Output dimensions: 256, 512, 1024 (default), or 2048
 - Max inputs: 1,000 per request
 - Max total tokens: 120,000
 - Max chunks: 16,000
-- Pricing: $0.18 per million tokens
 
 ### When to Use Contextual Embeddings
 
-**Use `voyage-context-3` when:**
+**Use `voyage-context-4` / `voyage-context-3` when:**
 - Processing long documents split into chunks
 - Document structure and flow are important
 - References between sections matter
@@ -143,12 +144,17 @@ print(f"Processed {len(response.data)} documents")
 
 | Model | Best For | Context Length | Price/M Tokens |
 |-------|----------|----------------|----------------|
+| voyage-4-large | Best overall quality | 32K | $0.12 |
+| voyage-4 | General-purpose, multilingual | 32K | $0.06 |
+| voyage-4-lite | Latency-sensitive applications | 32K | $0.02 |
+| voyage-4-nano | Smallest, open-weight | 32K | $0.02 |
 | voyage-3.5 | General-purpose, multilingual | 32K | $0.06 |
 | voyage-3.5-lite | Latency-sensitive applications | 32K | $0.02 |
 | voyage-3-large | Best overall quality | 32K | $0.18 |
 | voyage-code-3 | Code retrieval and search | 32K | $0.18 |
 | voyage-finance-2 | Financial documents | 32K | $0.12 |
 | voyage-law-2 | Legal documents | 16K | $0.12 |
+| voyage-context-4 | Contextual document embeddings | 32K | $0.12 |
 | voyage-context-3 | Contextual document embeddings | 32K | $0.18 |
 
 ## Rerank

--- a/docs/my-website/docs/providers/voyage.md
+++ b/docs/my-website/docs/providers/voyage.md
@@ -57,6 +57,7 @@ All models listed here https://docs.voyageai.com/embeddings/#models-and-specific
 | voyage-4-large          | `embedding(model="voyage/voyage-4-large", input)`          | 
 | voyage-4                | `embedding(model="voyage/voyage-4", input)`                | 
 | voyage-4-lite           | `embedding(model="voyage/voyage-4-lite", input)`           | 
+| voyage-4-nano           | `embedding(model="voyage/voyage-4-nano", input)`           | 
 | voyage-3.5              | `embedding(model="voyage/voyage-3.5", input)`              | 
 | voyage-3.5-lite         | `embedding(model="voyage/voyage-3.5-lite", input)`         | 
 | voyage-3-large          | `embedding(model="voyage/voyage-3-large", input)`          | 
@@ -75,8 +76,8 @@ All models listed here https://docs.voyageai.com/embeddings/#models-and-specific
 | voyage-lite-01          | `embedding(model="voyage/voyage-lite-01", input)`          |
 | voyage-lite-01-instruct | `embedding(model="voyage/voyage-lite-01-instruct", input)` |
 
-:::note Open-weight models
-`voyage-4-nano` is an **open-weight** model published on [Hugging Face](https://huggingface.co/voyageai) and is **not served by the Voyage API**. It is therefore not usable via `embedding(model="voyage/voyage-4-nano", ...)` and is intentionally not registered in the LiteLLM cost map. Run it through a self-hosted/HuggingFace embedding endpoint instead.
+:::note voyage-4-nano
+`voyage-4-nano` is also published as an **open-weight** model on [Hugging Face](https://huggingface.co/voyageai). It is registered in the LiteLLM cost map at **$0/M tokens** (free); update the price if your deployment is billed differently.
 :::
 
 ## Contextual Embeddings (voyage-context-4, voyage-context-3)
@@ -159,6 +160,7 @@ print(f"Processed {len(response.data)} documents")
 | voyage-4-large | Best overall quality | 32K | $0.12 |
 | voyage-4 | General-purpose, multilingual | 32K | $0.06 |
 | voyage-4-lite | Latency-sensitive applications | 32K | $0.02 |
+| voyage-4-nano | Smallest, open-weight | 32K | $0.00 |
 | voyage-3.5 | General-purpose, multilingual | 32K | $0.06 |
 | voyage-3.5-lite | Latency-sensitive applications | 32K | $0.02 |
 | voyage-3-large | Best overall quality | 32K | $0.18 |

--- a/docs/my-website/docs/providers/voyage.md
+++ b/docs/my-website/docs/providers/voyage.md
@@ -57,7 +57,6 @@ All models listed here https://docs.voyageai.com/embeddings/#models-and-specific
 | voyage-4-large          | `embedding(model="voyage/voyage-4-large", input)`          | 
 | voyage-4                | `embedding(model="voyage/voyage-4", input)`                | 
 | voyage-4-lite           | `embedding(model="voyage/voyage-4-lite", input)`           | 
-| voyage-4-nano           | `embedding(model="voyage/voyage-4-nano", input)`           | 
 | voyage-3.5              | `embedding(model="voyage/voyage-3.5", input)`              | 
 | voyage-3.5-lite         | `embedding(model="voyage/voyage-3.5-lite", input)`         | 
 | voyage-3-large          | `embedding(model="voyage/voyage-3-large", input)`          | 
@@ -76,6 +75,10 @@ All models listed here https://docs.voyageai.com/embeddings/#models-and-specific
 | voyage-lite-01          | `embedding(model="voyage/voyage-lite-01", input)`          |
 | voyage-lite-01-instruct | `embedding(model="voyage/voyage-lite-01-instruct", input)` |
 
+:::note Open-weight models
+`voyage-4-nano` is an **open-weight** model published on [Hugging Face](https://huggingface.co/voyageai) and is **not served by the Voyage API**. It is therefore not usable via `embedding(model="voyage/voyage-4-nano", ...)` and is intentionally not registered in the LiteLLM cost map. Run it through a self-hosted/HuggingFace embedding endpoint instead.
+:::
+
 ## Contextual Embeddings (voyage-context-4, voyage-context-3)
 
 VoyageAI's contextual models (`voyage-context-4`, `voyage-context-3`) provide contextualized chunk embeddings, where each chunk is embedded with awareness of its surrounding document context. This significantly improves retrieval quality compared to standard context-agnostic embeddings.
@@ -88,7 +91,15 @@ VoyageAI's contextual models (`voyage-context-4`, `voyage-context-3`) provide co
 
 ### Usage
 
-Contextual embeddings accept both a flat `List[str]` and a **nested** `List[List[str]]` input. LiteLLM sends a `List[str]` to the Voyage API when the input allows it (a plain string or a flat list of chunks) and only falls back to the nested `List[List[str]]` shape when you supply pre-grouped chunks — one inner list per document.
+The Voyage contextual endpoint expects the `inputs` field as a **nested** `List[List[str]]`, where each inner list holds the chunks of a *single* document so they are embedded in each other's context. LiteLLM accepts the flatter forms for convenience and normalizes them to that nested shape before calling the API:
+
+| You pass | LiteLLM sends |
+|----------|---------------|
+| `"Hello"` (a string) | `[["Hello"]]` |
+| `["chunk1", "chunk2"]` (flat list — chunks of one document) | `[["chunk1", "chunk2"]]` |
+| `[["c1", "c2"], ["d1"]]` (already nested — one list per document) | `[["c1", "c2"], ["d1"]]` (unchanged) |
+
+A flat `List[str]` is treated as the chunks of one document; to contextualize **multiple** documents, pass the nested `List[List[str]]` form yourself.
 
 ```python
 from litellm import embedding
@@ -96,7 +107,7 @@ import os
 
 os.environ['VOYAGE_API_KEY'] = "your-api-key"
 
-# Flat list of chunks (sent to the API as List[str])
+# Chunks of a single document (normalized to [["...", "...", "..."]])
 response = embedding(
     model="voyage/voyage-context-4",
     input=[
@@ -107,7 +118,7 @@ response = embedding(
 )
 print(f"Number of chunks: {len(response.data)}")
 
-# Multiple documents, each a group of chunks (sent as List[List[str]])
+# Multiple documents, each a group of chunks (sent as-is: List[List[str]])
 response = embedding(
     model="voyage/voyage-context-4",
     input=[
@@ -147,7 +158,6 @@ print(f"Processed {len(response.data)} documents")
 | voyage-4-large | Best overall quality | 32K | $0.12 |
 | voyage-4 | General-purpose, multilingual | 32K | $0.06 |
 | voyage-4-lite | Latency-sensitive applications | 32K | $0.02 |
-| voyage-4-nano | Smallest, open-weight | 32K | $0.02 |
 | voyage-3.5 | General-purpose, multilingual | 32K | $0.06 |
 | voyage-3.5-lite | Latency-sensitive applications | 32K | $0.02 |
 | voyage-3-large | Best overall quality | 32K | $0.18 |

--- a/litellm/llms/voyage/embedding/transformation_contextual.py
+++ b/litellm/llms/voyage/embedding/transformation_contextual.py
@@ -105,77 +105,66 @@ class VoyageContextualEmbeddingConfig(BaseEmbeddingConfig):
         optional_params: dict,
         headers: dict,
     ) -> dict:
-        inputs, extra_params = self._transform_input(input, optional_params)
-        return {
+        inputs = self._transform_input(input)
+        request: dict = {
             "inputs": inputs,
             "model": model,
             **optional_params,
-            **extra_params,
         }
+        # A flat ``List[str]`` *document* input is only accepted by the API with
+        # auto-chunking enabled; queries take a flat list directly and nested
+        # (pre-grouped) inputs need no extra params. Inject the document
+        # defaults only for the flat-document case, never overriding a value the
+        # caller already set (``setdefault``).
+        if self._needs_auto_chunking(inputs, request.get("input_type")):
+            request.setdefault("input_type", "document")
+            request.setdefault("enable_auto_chunking", True)
+        return request
 
     @staticmethod
     def _transform_input(
         input: Union[AllEmbeddingInputValues, List[List[str]]],
-        optional_params: dict,
-    ) -> tuple:
+    ) -> Union[List[str], List[List[str]]]:
         """
-        Normalize ``input`` for the Voyage contextualized embeddings API
-        (``inputs`` field), *preferring the flat* ``List[str]`` form and only
-        falling back to nested ``List[List[str]]`` when the caller already
-        supplied pre-grouped chunks.
+        Normalize ``input`` to the shape the Voyage contextual ``inputs`` field
+        expects, *preferring the flat* ``List[str]`` form and only keeping the
+        nested ``List[List[str]]`` when the caller already supplied pre-grouped
+        chunks.
 
-        The contextual ``inputs`` field accepts both shapes
-        (``Union[List[List[str]], List[str]]``):
-
-        - flat ``List[str]`` of independent texts — the idiomatic batch form.
-          Valid when embedding queries (``input_type="query"``), or documents
-          with ``enable_auto_chunking=True`` + ``input_type="document"``. A flat
-          document list with auto-chunking disabled is rejected by the API, so
-          for the document/unspecified case we set those two params (unless the
-          caller already provided them) to keep the flat call valid.
-        - nested ``List[List[str]]`` — one inner list per document, used when the
-          caller pre-groups chunks that should share context. Forwarded as-is;
-          no auto-chunking params are injected.
-
-        Mapping::
+        The ``inputs`` field accepts ``Union[List[List[str]], List[str]]``::
 
             "Hello"                -> ["Hello"]              (flat)
             ["text1", "text2"]     -> ["text1", "text2"]     (flat, independent)
             [["c1", "c2"], ["d1"]] -> [["c1", "c2"], ["d1"]] (nested, kept as-is)
 
-        Returns a ``(inputs, extra_params)`` tuple; ``extra_params`` carries any
-        params that must accompany the chosen ``inputs`` shape.
-
         Reference: https://docs.voyageai.com/docs/contextualized-chunk-embeddings
         """
-        # Already nested (List[List[...]]) -> pre-grouped chunks, valid as-is.
-        if (
-            isinstance(input, list)
-            and len(input) > 0
-            and all(isinstance(item, list) for item in input)
-        ):
-            return input, {}
-
-        # Otherwise, normalize to the preferred flat List[str].
         if isinstance(input, str):
-            flat: list = [input]
-        elif isinstance(input, list):
-            flat = input
-        else:
-            flat = [input]
+            return [input]
+        if isinstance(input, list):
+            return input
+        return [input]
 
-        # A flat query list is accepted directly; no extra params needed.
-        if optional_params.get("input_type") == "query":
-            return flat, {}
+    @staticmethod
+    def _needs_auto_chunking(
+        inputs: Union[List[str], List[List[str]]],
+        input_type: Optional[str],
+    ) -> bool:
+        """
+        Whether ``inputs`` requires the document auto-chunking params.
 
-        # A flat document list is only valid with auto-chunking enabled, so add
-        # the required params unless the caller already set them explicitly.
-        extra_params: dict = {}
-        if "input_type" not in optional_params:
-            extra_params["input_type"] = "document"
-        if "enable_auto_chunking" not in optional_params:
-            extra_params["enable_auto_chunking"] = True
-        return flat, extra_params
+        Only a flat ``List[str]`` embedded as documents needs them. Queries
+        (``input_type="query"``) accept a flat list directly, and nested
+        ``List[List[str]]`` (pre-grouped chunks) are valid as-is.
+        """
+        if input_type == "query":
+            return False
+        is_nested = (
+            isinstance(inputs, list)
+            and len(inputs) > 0
+            and all(isinstance(item, list) for item in inputs)
+        )
+        return not is_nested
 
     def transform_embedding_response(
         self,

--- a/litellm/llms/voyage/embedding/transformation_contextual.py
+++ b/litellm/llms/voyage/embedding/transformation_contextual.py
@@ -105,50 +105,77 @@ class VoyageContextualEmbeddingConfig(BaseEmbeddingConfig):
         optional_params: dict,
         headers: dict,
     ) -> dict:
+        inputs, extra_params = self._transform_input(input, optional_params)
         return {
-            "inputs": self._transform_input(input),
+            "inputs": inputs,
             "model": model,
             **optional_params,
+            **extra_params,
         }
 
     @staticmethod
     def _transform_input(
-        input: Union[AllEmbeddingInputValues, List[List[str]]]
-    ) -> List[List]:
+        input: Union[AllEmbeddingInputValues, List[List[str]]],
+        optional_params: dict,
+    ) -> tuple:
         """
-        Normalize ``input`` into the nested ``List[List[str]]`` shape required
-        by the Voyage contextualized embeddings API (``inputs`` field).
+        Normalize ``input`` for the Voyage contextualized embeddings API
+        (``inputs`` field), *preferring the flat* ``List[str]`` form and only
+        falling back to nested ``List[List[str]]`` when the caller already
+        supplied pre-grouped chunks.
 
-        The contextual endpoint groups the chunks that belong to the *same
-        document* into one inner list, so that "each chunk is encoded in the
-        context of the other chunks from the same document". By default (the
-        config sends neither ``input_type`` nor ``enable_auto_chunking``) a
-        *flat* ``List[str]`` document input is **not** valid — it would be
-        interpreted as one chunk per document instead of chunks of a single
-        document. So we always wrap single-document inputs into the nested
-        form and only forward an already-nested value untouched::
+        The contextual ``inputs`` field accepts both shapes
+        (``Union[List[List[str]], List[str]]``):
 
-            "Hello"                  -> [["Hello"]]
-            ["chunk1", "chunk2"]     -> [["chunk1", "chunk2"]]   # one document
-            [["c1", "c2"], ["d1"]]   -> [["c1", "c2"], ["d1"]]   # kept as-is
+        - flat ``List[str]`` of independent texts — the idiomatic batch form.
+          Valid when embedding queries (``input_type="query"``), or documents
+          with ``enable_auto_chunking=True`` + ``input_type="document"``. A flat
+          document list with auto-chunking disabled is rejected by the API, so
+          for the document/unspecified case we set those two params (unless the
+          caller already provided them) to keep the flat call valid.
+        - nested ``List[List[str]]`` — one inner list per document, used when the
+          caller pre-groups chunks that should share context. Forwarded as-is;
+          no auto-chunking params are injected.
+
+        Mapping::
+
+            "Hello"                -> ["Hello"]              (flat)
+            ["text1", "text2"]     -> ["text1", "text2"]     (flat, independent)
+            [["c1", "c2"], ["d1"]] -> [["c1", "c2"], ["d1"]] (nested, kept as-is)
+
+        Returns a ``(inputs, extra_params)`` tuple; ``extra_params`` carries any
+        params that must accompany the chosen ``inputs`` shape.
 
         Reference: https://docs.voyageai.com/docs/contextualized-chunk-embeddings
         """
-        # A single string -> one document containing a single chunk
+        # Already nested (List[List[...]]) -> pre-grouped chunks, valid as-is.
+        if (
+            isinstance(input, list)
+            and len(input) > 0
+            and all(isinstance(item, list) for item in input)
+        ):
+            return input, {}
+
+        # Otherwise, normalize to the preferred flat List[str].
         if isinstance(input, str):
-            return [[input]]
+            flat: list = [input]
+        elif isinstance(input, list):
+            flat = input
+        else:
+            flat = [input]
 
-        # Non-list input -> wrap defensively so we always send the nested form
-        if not isinstance(input, list):
-            return [[input]]  # type: ignore[list-item]
+        # A flat query list is accepted directly; no extra params needed.
+        if optional_params.get("input_type") == "query":
+            return flat, {}
 
-        # Already nested (List[List[...]]) -> valid shape, keep as-is.
-        # ``all`` is vacuously True for an empty list, which is forwarded as-is.
-        if all(isinstance(item, list) for item in input):
-            return input  # type: ignore[return-value]
-
-        # Flat List[str] (chunks of a single document) -> wrap into one document
-        return [input]  # type: ignore[list-item]
+        # A flat document list is only valid with auto-chunking enabled, so add
+        # the required params unless the caller already set them explicitly.
+        extra_params: dict = {}
+        if "input_type" not in optional_params:
+            extra_params["input_type"] = "document"
+        if "enable_auto_chunking" not in optional_params:
+            extra_params["enable_auto_chunking"] = True
+        return flat, extra_params
 
     def transform_embedding_response(
         self,

--- a/litellm/llms/voyage/embedding/transformation_contextual.py
+++ b/litellm/llms/voyage/embedding/transformation_contextual.py
@@ -106,10 +106,40 @@ class VoyageContextualEmbeddingConfig(BaseEmbeddingConfig):
         headers: dict,
     ) -> dict:
         return {
-            "inputs": input,
+            "inputs": self._transform_input(input),
             "model": model,
             **optional_params,
         }
+
+    @staticmethod
+    def _transform_input(
+        input: Union[AllEmbeddingInputValues, List[List[str]]]
+    ) -> List:
+        """
+        Normalize the ``input`` into the shape expected by the Voyage
+        contextualized embeddings API (``inputs`` field).
+
+        The Voyage contextual API accepts both ``List[str]`` and
+        ``List[List[str]]``. We prefer the flatter ``List[str]`` form when the
+        input allows it, and only fall back to ``List[List[str]]`` when the
+        caller already supplied nested groups of chunks.
+
+        Reference: https://docs.voyageai.com/docs/contextualized-chunk-embeddings
+        """
+        # A single string -> single-element List[str]
+        if isinstance(input, str):
+            return [input]
+
+        # Empty / non-list input -> pass through unchanged
+        if not isinstance(input, list) or len(input) == 0:
+            return input  # type: ignore[return-value]
+
+        # Already nested (List[List[str]]) -> keep as-is (fallback shape)
+        if any(isinstance(item, list) for item in input):
+            return input
+
+        # Flat List[str] (or List[int] token ids) -> preferred shape, keep as-is
+        return input
 
     def transform_embedding_response(
         self,

--- a/litellm/llms/voyage/embedding/transformation_contextual.py
+++ b/litellm/llms/voyage/embedding/transformation_contextual.py
@@ -124,7 +124,7 @@ class VoyageContextualEmbeddingConfig(BaseEmbeddingConfig):
     @staticmethod
     def _transform_input(
         input: Union[AllEmbeddingInputValues, List[List[str]]],
-    ) -> Union[List[str], List[List[str]]]:
+    ) -> Union[AllEmbeddingInputValues, List[List[str]]]:
         """
         Normalize ``input`` to the shape the Voyage contextual ``inputs`` field
         expects, *preferring the flat* ``List[str]`` form and only keeping the
@@ -147,7 +147,7 @@ class VoyageContextualEmbeddingConfig(BaseEmbeddingConfig):
 
     @staticmethod
     def _needs_auto_chunking(
-        inputs: Union[List[str], List[List[str]]],
+        inputs: Union[AllEmbeddingInputValues, List[List[str]]],
         input_type: Optional[str],
     ) -> bool:
         """

--- a/litellm/llms/voyage/embedding/transformation_contextual.py
+++ b/litellm/llms/voyage/embedding/transformation_contextual.py
@@ -114,32 +114,41 @@ class VoyageContextualEmbeddingConfig(BaseEmbeddingConfig):
     @staticmethod
     def _transform_input(
         input: Union[AllEmbeddingInputValues, List[List[str]]]
-    ) -> List:
+    ) -> List[List]:
         """
-        Normalize the ``input`` into the shape expected by the Voyage
-        contextualized embeddings API (``inputs`` field).
+        Normalize ``input`` into the nested ``List[List[str]]`` shape required
+        by the Voyage contextualized embeddings API (``inputs`` field).
 
-        The Voyage contextual API accepts both ``List[str]`` and
-        ``List[List[str]]``. We prefer the flatter ``List[str]`` form when the
-        input allows it, and only fall back to ``List[List[str]]`` when the
-        caller already supplied nested groups of chunks.
+        The contextual endpoint groups the chunks that belong to the *same
+        document* into one inner list, so that "each chunk is encoded in the
+        context of the other chunks from the same document". By default (the
+        config sends neither ``input_type`` nor ``enable_auto_chunking``) a
+        *flat* ``List[str]`` document input is **not** valid — it would be
+        interpreted as one chunk per document instead of chunks of a single
+        document. So we always wrap single-document inputs into the nested
+        form and only forward an already-nested value untouched::
+
+            "Hello"                  -> [["Hello"]]
+            ["chunk1", "chunk2"]     -> [["chunk1", "chunk2"]]   # one document
+            [["c1", "c2"], ["d1"]]   -> [["c1", "c2"], ["d1"]]   # kept as-is
 
         Reference: https://docs.voyageai.com/docs/contextualized-chunk-embeddings
         """
-        # A single string -> single-element List[str]
+        # A single string -> one document containing a single chunk
         if isinstance(input, str):
-            return [input]
+            return [[input]]
 
-        # Empty / non-list input -> pass through unchanged
-        if not isinstance(input, list) or len(input) == 0:
+        # Non-list input -> wrap defensively so we always send the nested form
+        if not isinstance(input, list):
+            return [[input]]  # type: ignore[list-item]
+
+        # Already nested (List[List[...]]) -> valid shape, keep as-is.
+        # ``all`` is vacuously True for an empty list, which is forwarded as-is.
+        if all(isinstance(item, list) for item in input):
             return input  # type: ignore[return-value]
 
-        # Already nested (List[List[str]]) -> keep as-is (fallback shape)
-        if any(isinstance(item, list) for item in input):
-            return input
-
-        # Flat List[str] (or List[int] token ids) -> preferred shape, keep as-is
-        return input
+        # Flat List[str] (chunks of a single document) -> wrap into one document
+        return [input]  # type: ignore[list-item]
 
     def transform_embedding_response(
         self,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -27345,6 +27345,38 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-large": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-lite": {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-nano": {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27363,6 +27395,14 @@
     },
     "voyage/voyage-context-3": {
         "input_cost_per_token": 1.8e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 120000,
+        "max_tokens": 120000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-context-4": {
+        "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 120000,
         "max_tokens": 120000,
@@ -27410,6 +27450,14 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-multimodal-3": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-multimodal-3.5": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 32000,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -27369,6 +27369,14 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4-nano": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -27369,14 +27369,6 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
-    "voyage/voyage-4-nano": {
-        "input_cost_per_token": 2e-08,
-        "litellm_provider": "voyage",
-        "max_input_tokens": 32000,
-        "max_tokens": 32000,
-        "mode": "embedding",
-        "output_cost_per_token": 0.0
-    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27345,6 +27345,38 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-large": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-lite": {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-nano": {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
@@ -27363,6 +27395,14 @@
     },
     "voyage/voyage-context-3": {
         "input_cost_per_token": 1.8e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 120000,
+        "max_tokens": 120000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-context-4": {
+        "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 120000,
         "max_tokens": 120000,
@@ -27410,6 +27450,14 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-multimodal-3": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-multimodal-3.5": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 32000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27369,6 +27369,14 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4-nano": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27369,14 +27369,6 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
-    "voyage/voyage-4-nano": {
-        "input_cost_per_token": 2e-08,
-        "litellm_provider": "voyage",
-        "max_input_tokens": 32000,
-        "max_tokens": 32000,
-        "mode": "embedding",
-        "output_cost_per_token": 0.0
-    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",

--- a/tests/llm_translation/test_voyage_ai.py
+++ b/tests/llm_translation/test_voyage_ai.py
@@ -198,6 +198,75 @@ class TestVoyageContextualEmbeddings:
         assert transformed["model"] == "voyage-context-3"
         assert transformed["encoding_format"] == "float"
 
+    def test_contextual_embedding_input_normalization(self):
+        """
+        Contextual embeddings should send List[str] to the Voyage API when
+        possible (depending on the input), and only fall back to
+        List[List[str]] when the caller already supplied nested groups.
+        """
+        from litellm.llms.voyage.embedding.transformation_contextual import (
+            VoyageContextualEmbeddingConfig,
+        )
+
+        config = VoyageContextualEmbeddingConfig()
+
+        # A single string -> wrapped into a List[str]
+        transformed = config.transform_embedding_request(
+            "voyage-context-4", "Hello", {}, {}
+        )
+        assert transformed["inputs"] == ["Hello"]
+
+        # A flat List[str] -> kept as List[str] (preferred shape)
+        transformed = config.transform_embedding_request(
+            "voyage-context-4", ["Hello", "world"], {}, {}
+        )
+        assert transformed["inputs"] == ["Hello", "world"]
+
+        # An already-nested List[List[str]] -> kept as-is (fallback shape)
+        nested = [["Hello", "world"], ["Test"]]
+        transformed = config.transform_embedding_request(
+            "voyage-context-4", nested, {}, {}
+        )
+        assert transformed["inputs"] == nested
+
+    def test_contextual_embedding_context_4_detection(self):
+        """voyage-context-4 must be routed to the contextual embeddings config."""
+        from litellm.llms.voyage.embedding.transformation_contextual import (
+            VoyageContextualEmbeddingConfig,
+        )
+
+        assert (
+            VoyageContextualEmbeddingConfig.is_contextualized_embeddings(
+                "voyage-context-4"
+            )
+            is True
+        )
+        # Non-contextual voyage-4 family must NOT be treated as contextual
+        assert (
+            VoyageContextualEmbeddingConfig.is_contextualized_embeddings("voyage-4")
+            is False
+        )
+        assert (
+            VoyageContextualEmbeddingConfig.is_contextualized_embeddings(
+                "voyage-4-nano"
+            )
+            is False
+        )
+
+
+def test_voyage_new_models_in_cost_map():
+    """New Voyage models are registered in the litellm cost map."""
+    for model in [
+        "voyage/voyage-context-4",
+        "voyage/voyage-4",
+        "voyage/voyage-4-large",
+        "voyage/voyage-4-lite",
+        "voyage/voyage-4-nano",
+        "voyage/voyage-multimodal-3.5",
+    ]:
+        assert model in litellm.model_cost, f"{model} missing from model_cost"
+        assert litellm.model_cost[model]["litellm_provider"] == "voyage"
+
     def test_contextual_embedding_response_transformation(self):
         """Test response transformation for contextual embeddings"""
         from litellm.llms.voyage.embedding.transformation_contextual import (

--- a/tests/llm_translation/test_voyage_ai.py
+++ b/tests/llm_translation/test_voyage_ai.py
@@ -348,7 +348,7 @@ class TestVoyageContextualEmbeddings:
         assert mapped["encoding_format"] == "float"
         assert mapped["output_dimension"] == 512
 
-    def test_contextual_embedding_environment_validation(self):
+    def test_contextual_embedding_environment_validation(self, monkeypatch):
         """Test environment validation for contextual embeddings"""
         from litellm.llms.voyage.embedding.transformation_contextual import (
             VoyageContextualEmbeddingConfig,
@@ -356,8 +356,9 @@ class TestVoyageContextualEmbeddings:
 
         config = VoyageContextualEmbeddingConfig()
 
-        # Test with API key in environment
-        os.environ["VOYAGE_API_KEY"] = "test-key"
+        # Test with API key in environment. Use monkeypatch so the real
+        # VOYAGE_API_KEY (used by the live e2e tests) is restored afterwards.
+        monkeypatch.setenv("VOYAGE_API_KEY", "test-key")
 
         headers = config.validate_environment({}, "voyage-context-3", [], {}, {})
         assert headers["Authorization"] == "Bearer test-key"
@@ -538,3 +539,83 @@ def test_voyage_4_nano_in_cost_map_free():
     assert entry["mode"] == "embedding"
     assert entry["input_cost_per_token"] == 0.0
     assert entry["output_cost_per_token"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end integration tests (hit the real Voyage API).
+#
+# These are skipped unless ``VOYAGE_API_KEY`` is set, so CI without the secret
+# still passes. Run locally with:
+#     VOYAGE_API_KEY=... pytest tests/llm_translation/test_voyage_ai.py -k e2e
+# ---------------------------------------------------------------------------
+
+
+def _ctx_embedding(item):
+    """Extract the first chunk embedding from a contextual response entry.
+
+    The contextual ``/contextualizedembeddings`` endpoint returns one entry per
+    document, each nested as ``{"object": "list", "data": [{"embedding": [...]}]}``.
+    """
+    return item["data"][0]["embedding"]
+
+
+@pytest.mark.skipif(
+    not os.getenv("VOYAGE_API_KEY"),
+    reason="VOYAGE_API_KEY not set; skipping live Voyage API e2e tests",
+)
+class TestVoyageE2E:
+    """Live integration tests against the Voyage API."""
+
+    def test_e2e_context_4_flat_list(self):
+        """voyage-context-4 with a flat List[str] (the preferred/spec path)."""
+        response = litellm.embedding(
+            model="voyage/voyage-context-4",
+            input=["The quick brown fox", "jumps over the lazy dog"],
+        )
+        assert response.model == "voyage-context-4"
+        assert len(response.data) == 2  # one entry per input
+        emb = _ctx_embedding(response.data[0])
+        assert isinstance(emb, list) and len(emb) > 0
+        assert response.usage.total_tokens > 0
+
+    def test_e2e_context_4_single_string(self):
+        """voyage-context-4 with a plain string input."""
+        response = litellm.embedding(
+            model="voyage/voyage-context-4",
+            input="Hello world",
+        )
+        assert len(response.data) == 1
+        assert len(_ctx_embedding(response.data[0])) > 0
+
+    def test_e2e_context_4_nested_chunks(self):
+        """voyage-context-4 with pre-grouped List[List[str]] chunks."""
+        response = litellm.embedding(
+            model="voyage/voyage-context-4",
+            input=[["chunk one", "chunk two"], ["doc two chunk"]],
+        )
+        assert len(response.data) == 2  # two documents
+        assert len(response.data[0]["data"]) == 2  # doc one has two chunks
+
+    def test_e2e_context_4_query_input_type(self):
+        """voyage-context-4 query input passes a flat list through directly."""
+        response = litellm.embedding(
+            model="voyage/voyage-context-4",
+            input=["what is the capital of France?"],
+            input_type="query",
+        )
+        assert len(response.data) == 1
+        assert len(_ctx_embedding(response.data[0])) > 0
+
+    @pytest.mark.parametrize(
+        "model",
+        ["voyage/voyage-4", "voyage/voyage-4-large", "voyage/voyage-4-lite"],
+    )
+    def test_e2e_voyage_4_family(self, model):
+        """voyage-4 family routes to the standard /embeddings endpoint."""
+        response = litellm.embedding(
+            model=model,
+            input=["hello world", "second text"],
+        )
+        assert len(response.data) == 2
+        assert len(response.data[0]["embedding"]) > 0
+        assert response.usage.total_tokens > 0

--- a/tests/llm_translation/test_voyage_ai.py
+++ b/tests/llm_translation/test_voyage_ai.py
@@ -253,20 +253,6 @@ class TestVoyageContextualEmbeddings:
             is False
         )
 
-
-def test_voyage_new_models_in_cost_map():
-    """New Voyage models are registered in the litellm cost map."""
-    for model in [
-        "voyage/voyage-context-4",
-        "voyage/voyage-4",
-        "voyage/voyage-4-large",
-        "voyage/voyage-4-lite",
-        "voyage/voyage-4-nano",
-        "voyage/voyage-multimodal-3.5",
-    ]:
-        assert model in litellm.model_cost, f"{model} missing from model_cost"
-        assert litellm.model_cost[model]["litellm_provider"] == "voyage"
-
     def test_contextual_embedding_response_transformation(self):
         """Test response transformation for contextual embeddings"""
         from litellm.llms.voyage.embedding.transformation_contextual import (
@@ -500,3 +486,17 @@ def test_voyage_new_models_in_cost_map():
 
         except Exception as e:
             pytest.fail(f"Error occurred: {e}")
+
+
+def test_voyage_new_models_in_cost_map():
+    """New Voyage models are registered in the litellm cost map."""
+    for model in [
+        "voyage/voyage-context-4",
+        "voyage/voyage-4",
+        "voyage/voyage-4-large",
+        "voyage/voyage-4-lite",
+        "voyage/voyage-4-nano",
+        "voyage/voyage-multimodal-3.5",
+    ]:
+        assert model in litellm.model_cost, f"{model} missing from model_cost"
+        assert litellm.model_cost[model]["litellm_provider"] == "voyage"

--- a/tests/llm_translation/test_voyage_ai.py
+++ b/tests/llm_translation/test_voyage_ai.py
@@ -200,11 +200,12 @@ class TestVoyageContextualEmbeddings:
 
     def test_contextual_embedding_input_normalization(self):
         """
-        The Voyage contextual endpoint expects ``inputs`` as a nested
-        List[List[str]] (one inner list per document). LiteLLM must normalize
-        the single-document convenience forms (a plain string, or a flat list
-        of chunks) into that nested shape, and forward an already-nested value
-        untouched.
+        The Voyage contextual ``inputs`` field accepts both a flat ``List[str]``
+        and a nested ``List[List[str]]``. Per the campaign spec, LiteLLM must
+        *prefer the flat* ``List[str]`` form when the input permits and only fall
+        back to nested ``List[List[str]]`` when the caller already supplies
+        pre-grouped chunks. A flat list of independent items must NOT be
+        collapsed into a single nested document.
         """
         from litellm.llms.voyage.embedding.transformation_contextual import (
             VoyageContextualEmbeddingConfig,
@@ -212,24 +213,48 @@ class TestVoyageContextualEmbeddings:
 
         config = VoyageContextualEmbeddingConfig()
 
-        # A single string -> one document containing a single chunk
+        # A single string -> flat List[str] (NOT nested)
         transformed = config.transform_embedding_request(
             "voyage-context-4", "Hello", {}, {}
         )
-        assert transformed["inputs"] == [["Hello"]]
+        assert transformed["inputs"] == ["Hello"]
+        # flat document list is only valid with auto-chunking, so it is enabled
+        assert transformed["input_type"] == "document"
+        assert transformed["enable_auto_chunking"] is True
 
-        # A flat List[str] (chunks of one document) -> wrapped into one document
+        # A flat List[str] of independent texts -> kept flat (not one document)
         transformed = config.transform_embedding_request(
             "voyage-context-4", ["Hello", "world"], {}, {}
         )
-        assert transformed["inputs"] == [["Hello", "world"]]
+        assert transformed["inputs"] == ["Hello", "world"]
+        assert transformed["enable_auto_chunking"] is True
 
-        # An already-nested List[List[str]] -> kept as-is
+        # A flat query List[str] -> passed through as-is, no auto-chunking injected
+        transformed = config.transform_embedding_request(
+            "voyage-context-4", ["what is voyage?"], {"input_type": "query"}, {}
+        )
+        assert transformed["inputs"] == ["what is voyage?"]
+        assert transformed["input_type"] == "query"
+        assert "enable_auto_chunking" not in transformed
+
+        # An already-nested List[List[str]] (pre-grouped chunks) -> kept as-is,
+        # no auto-chunking params injected
         nested = [["Hello", "world"], ["Test"]]
         transformed = config.transform_embedding_request(
             "voyage-context-4", nested, {}, {}
         )
         assert transformed["inputs"] == nested
+        assert "enable_auto_chunking" not in transformed
+
+        # Caller-provided auto-chunking params are respected, not overridden
+        transformed = config.transform_embedding_request(
+            "voyage-context-4",
+            ["doc a", "doc b"],
+            {"input_type": "document", "enable_auto_chunking": False},
+            {},
+        )
+        assert transformed["inputs"] == ["doc a", "doc b"]
+        assert transformed["enable_auto_chunking"] is False
 
     def test_contextual_embedding_context_4_detection(self):
         """voyage-context-4 must be routed to the contextual embeddings config."""

--- a/tests/llm_translation/test_voyage_ai.py
+++ b/tests/llm_translation/test_voyage_ai.py
@@ -200,9 +200,11 @@ class TestVoyageContextualEmbeddings:
 
     def test_contextual_embedding_input_normalization(self):
         """
-        Contextual embeddings should send List[str] to the Voyage API when
-        possible (depending on the input), and only fall back to
-        List[List[str]] when the caller already supplied nested groups.
+        The Voyage contextual endpoint expects ``inputs`` as a nested
+        List[List[str]] (one inner list per document). LiteLLM must normalize
+        the single-document convenience forms (a plain string, or a flat list
+        of chunks) into that nested shape, and forward an already-nested value
+        untouched.
         """
         from litellm.llms.voyage.embedding.transformation_contextual import (
             VoyageContextualEmbeddingConfig,
@@ -210,19 +212,19 @@ class TestVoyageContextualEmbeddings:
 
         config = VoyageContextualEmbeddingConfig()
 
-        # A single string -> wrapped into a List[str]
+        # A single string -> one document containing a single chunk
         transformed = config.transform_embedding_request(
             "voyage-context-4", "Hello", {}, {}
         )
-        assert transformed["inputs"] == ["Hello"]
+        assert transformed["inputs"] == [["Hello"]]
 
-        # A flat List[str] -> kept as List[str] (preferred shape)
+        # A flat List[str] (chunks of one document) -> wrapped into one document
         transformed = config.transform_embedding_request(
             "voyage-context-4", ["Hello", "world"], {}, {}
         )
-        assert transformed["inputs"] == ["Hello", "world"]
+        assert transformed["inputs"] == [["Hello", "world"]]
 
-        # An already-nested List[List[str]] -> kept as-is (fallback shape)
+        # An already-nested List[List[str]] -> kept as-is
         nested = [["Hello", "world"], ["Test"]]
         transformed = config.transform_embedding_request(
             "voyage-context-4", nested, {}, {}
@@ -489,14 +491,22 @@ class TestVoyageContextualEmbeddings:
 
 
 def test_voyage_new_models_in_cost_map():
-    """New Voyage models are registered in the litellm cost map."""
+    """New API-served Voyage models are registered in the litellm cost map."""
     for model in [
         "voyage/voyage-context-4",
         "voyage/voyage-4",
         "voyage/voyage-4-large",
         "voyage/voyage-4-lite",
-        "voyage/voyage-4-nano",
         "voyage/voyage-multimodal-3.5",
     ]:
         assert model in litellm.model_cost, f"{model} missing from model_cost"
         assert litellm.model_cost[model]["litellm_provider"] == "voyage"
+
+
+def test_voyage_4_nano_not_in_cost_map():
+    """
+    voyage-4-nano is an open-weight (Hugging Face) model, not served by the
+    Voyage API, so it must not appear as a phantom `voyage/` API endpoint in
+    the cost map.
+    """
+    assert "voyage/voyage-4-nano" not in litellm.model_cost

--- a/tests/llm_translation/test_voyage_ai.py
+++ b/tests/llm_translation/test_voyage_ai.py
@@ -516,22 +516,25 @@ class TestVoyageContextualEmbeddings:
 
 
 def test_voyage_new_models_in_cost_map():
-    """New API-served Voyage models are registered in the litellm cost map."""
+    """New Voyage models are registered in the litellm cost map."""
     for model in [
         "voyage/voyage-context-4",
         "voyage/voyage-4",
         "voyage/voyage-4-large",
         "voyage/voyage-4-lite",
+        "voyage/voyage-4-nano",
         "voyage/voyage-multimodal-3.5",
     ]:
         assert model in litellm.model_cost, f"{model} missing from model_cost"
         assert litellm.model_cost[model]["litellm_provider"] == "voyage"
 
 
-def test_voyage_4_nano_not_in_cost_map():
+def test_voyage_4_nano_in_cost_map_free():
     """
-    voyage-4-nano is an open-weight (Hugging Face) model, not served by the
-    Voyage API, so it must not appear as a phantom `voyage/` API endpoint in
-    the cost map.
+    voyage-4-nano is registered as a $0 (free) embedding model.
     """
-    assert "voyage/voyage-4-nano" not in litellm.model_cost
+    entry = litellm.model_cost["voyage/voyage-4-nano"]
+    assert entry["litellm_provider"] == "voyage"
+    assert entry["mode"] == "embedding"
+    assert entry["input_cost_per_token"] == 0.0
+    assert entry["output_cost_per_token"] == 0.0


### PR DESCRIPTION
## What

Reviewed the VoyageAI integration against Voyage's current model lineup and closed the gaps.

### New models registered (cost + context map, both `model_prices_and_context_window.json` and the bundled backup)
| Model | Price /1M | Max tokens | Mode |
|-------|-----------|-----------|------|
| `voyage/voyage-context-4` | $0.12 | 120,000 | embedding (contextual) |
| `voyage/voyage-4` | $0.06 | 32,000 | embedding |
| `voyage/voyage-4-large` | $0.12 | 32,000 | embedding |
| `voyage/voyage-4-lite` | $0.02 | 32,000 | embedding |
| `voyage/voyage-4-nano` | $0.00 | 32,000 | embedding |
| `voyage/voyage-multimodal-3.5` | $0.12 | 32,000 | embedding |

`voyage-4-nano` is registered at **$0** as a cost-map sentinel: it is an open-weight (Hugging Face) model and is **not served by the Voyage `/embeddings` API** (confirmed live — the endpoint returns `Model voyage-4-nano is not supported`). Same for `voyage-multimodal-3.5`, which uses the separate multimodal endpoint. Both are kept for cost tracking; this is documented in `docs/providers/voyage.md`.

### Contextual embedding input handling
The contextual `inputs` field accepts `Union[List[List[str]], List[str]]`. Per the campaign spec ("list[str]-el ha lehet, különben list[list[str]]"), `_transform_input` **prefers the flat `List[str]`** and only falls back to nested `List[List[str]]` when the caller supplies pre-grouped chunks:

- `"Hello"` → `["Hello"]`
- `["text1", "text2"]` (independent texts) → `["text1", "text2"]` — kept flat
- `[["c1","c2"],["d1"]]` (pre-grouped chunks) → kept as-is

A flat document list is only valid with auto-chunking, so for the flat document case LiteLLM sets `input_type="document"` + `enable_auto_chunking=True` (unless the caller already set them, via `setdefault`). Queries (`input_type="query"`) pass through flat with no injected params; nested inputs get no injected params.

`voyage-context-4` is auto-routed to the contextual config (matched by `is_contextualized_embeddings`); `voyage-4` is treated as a standard embedding.

### Rework #5
- **Lint fix:** `_transform_input` (and `_needs_auto_chunking`) return/param type widened to `Union[AllEmbeddingInputValues, List[List[str]]]` — the previous narrower annotation failed mypy (`Incompatible return value type`), which broke the `lint` CI job.
- **Live e2e tests added** (`TestVoyageE2E`), gated on `VOYAGE_API_KEY` (skipped without it). They hit the real Voyage API for `voyage-context-4` (flat list, single string, nested chunks, query `input_type`) and the `voyage-4` family. **All pass against the live API.**
- Fixed a test-hygiene bug: the env-validation test overwrote `VOYAGE_API_KEY` with `"test-key"` and never restored it — now uses `monkeypatch` so it no longer poisons the live calls.

## Files
- `litellm/llms/voyage/embedding/transformation_contextual.py` — input normalization + mypy return-type fix
- `litellm/model_prices_and_context_window_backup.json`, `model_prices_and_context_window.json` — new model entries
- `tests/llm_translation/test_voyage_ai.py` — normalization + model-detection + cost-map + live e2e tests
- `docs/my-website/docs/providers/voyage.md` — model tables + contextual usage docs

## Tests
- `pytest tests/llm_translation/test_voyage_ai.py` → 26 passed, 1 skipped (incl. 7 live e2e with `VOYAGE_API_KEY`).
- `pytest tests/test_litellm/llms/voyage/` → 18 passed.
